### PR TITLE
Support for OCI media types

### DIFF
--- a/src/Valleysoft.DockerRegistryClient/ManifestMediaTypes.cs
+++ b/src/Valleysoft.DockerRegistryClient/ManifestMediaTypes.cs
@@ -2,11 +2,14 @@
  
 public static class ManifestMediaTypes
 {
-    public const string ManifestSchema1 = "application/vnd.docker.distribution.manifest.v1+json";
-    public const string ManifestSchema1Signed = "application/vnd.docker.distribution.manifest.v1+prettyjws";
-    public const string ManifestSchema2 = "application/vnd.docker.distribution.manifest.v2+json";
-    public const string ManifestList = "application/vnd.docker.distribution.manifest.list.v2+json";
+    public const string DockerManifestSchema1 = "application/vnd.docker.distribution.manifest.v1+json";
+    public const string DockerManifestSchema1Signed = "application/vnd.docker.distribution.manifest.v1+prettyjws";
+    public const string DockerManifestSchema2 = "application/vnd.docker.distribution.manifest.v2+json";
+    public const string DockerManifestList = "application/vnd.docker.distribution.manifest.list.v2+json";
 
-    public const string ContainerConfig = "application/vnd.docker.container.image.v1+json";
-    public const string GzippedTar = "application/vnd.docker.image.rootfs.diff.tar.gzip";
+    public const string OciManifestSchema1 = "application/vnd.oci.image.manifest.v1+json";
+    public const string OciManifestList1 = "application/vnd.oci.image.index.v1+json";
+
+    //public const string DockerContainerConfig = "application/vnd.docker.container.image.v1+json";
+    //public const string DockerGzippedTar = "application/vnd.docker.image.rootfs.diff.tar.gzip";
 }

--- a/src/Valleysoft.DockerRegistryClient/ManifestOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/ManifestOperations.cs
@@ -34,9 +34,11 @@ internal class ManifestOperations : IServiceOperations<DockerRegistryClient>, IM
     private static HttpRequestMessage CreateGetRequestMessage(Uri requestUri, HttpMethod method)
     {
         HttpRequestMessage request = new(method, requestUri);
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(ManifestMediaTypes.ManifestSchema1));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(ManifestMediaTypes.ManifestSchema2));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(ManifestMediaTypes.ManifestList));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(ManifestMediaTypes.DockerManifestSchema1));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(ManifestMediaTypes.DockerManifestSchema2));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(ManifestMediaTypes.DockerManifestList));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(ManifestMediaTypes.OciManifestSchema1));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(ManifestMediaTypes.OciManifestList1));
         return request;
     }
 
@@ -55,18 +57,26 @@ internal class ManifestOperations : IServiceOperations<DockerRegistryClient>, IM
 
         return mediaType switch
         {
-            ManifestMediaTypes.ManifestSchema1 or ManifestMediaTypes.ManifestSchema1Signed => new ManifestInfo(
+            ManifestMediaTypes.DockerManifestSchema1 or ManifestMediaTypes.DockerManifestSchema1Signed => new ManifestInfo(
                 mediaType,
                 dockerContentDigest,
-                SafeJsonConvert.DeserializeObject<Manifest_Schema1>(content)),
-            ManifestMediaTypes.ManifestSchema2 => new ManifestInfo(
+                SafeJsonConvert.DeserializeObject<DockerManifestV1>(content)),
+            ManifestMediaTypes.DockerManifestSchema2 => new ManifestInfo(
                 mediaType,
                 dockerContentDigest,
-                SafeJsonConvert.DeserializeObject<Manifest_Schema2>(content)),
-            ManifestMediaTypes.ManifestList => new ManifestInfo(
+                SafeJsonConvert.DeserializeObject<DockerManifestV2>(content)),
+            ManifestMediaTypes.DockerManifestList => new ManifestInfo(
                 mediaType,
                 dockerContentDigest,
                 SafeJsonConvert.DeserializeObject<ManifestList>(content)),
+            ManifestMediaTypes.OciManifestSchema1 => new ManifestInfo(
+                mediaType,
+                dockerContentDigest,
+                SafeJsonConvert.DeserializeObject<OciManifest>(content)),
+            ManifestMediaTypes.OciManifestList1 => new ManifestInfo(
+                mediaType,
+                dockerContentDigest,
+                SafeJsonConvert.DeserializeObject<OciManifestList>(content)),
             _ => throw new NotSupportedException($"Content type '{mediaType}' not supported."),
         };
     }

--- a/src/Valleysoft.DockerRegistryClient/Models/DockerManifestV1.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/DockerManifestV1.cs
@@ -2,9 +2,9 @@
 
 namespace Valleysoft.DockerRegistryClient.Models;
 
-public class Manifest_Schema1 : Manifest
+public class DockerManifestV1 : Manifest
 {
-    public Manifest_Schema1()
+    public DockerManifestV1()
     {
         SchemaVersion = 1;
     }

--- a/src/Valleysoft.DockerRegistryClient/Models/DockerManifestV2.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/DockerManifestV2.cs
@@ -5,11 +5,11 @@ namespace Valleysoft.DockerRegistryClient.Models;
 /// <summary>
 /// The image manifest provides a configuration and a set of layers for a container image. It’s the direct replacement for the schema-1 manifest.
 /// </summary>
-public class Manifest_Schema2 : ManifestWithMediaType
+public class DockerManifestV2 : ManifestWithMediaType
 {
-    public Manifest_Schema2()
+    public DockerManifestV2()
     {
-        MediaType = ManifestMediaTypes.ManifestSchema2;
+        MediaType = ManifestMediaTypes.DockerManifestSchema2;
         SchemaVersion = 2;
     }
 

--- a/src/Valleysoft.DockerRegistryClient/Models/ManifestInfo.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/ManifestInfo.cs
@@ -1,6 +1,4 @@
-﻿using Newtonsoft.Json;
-
-namespace Valleysoft.DockerRegistryClient.Models;
+﻿namespace Valleysoft.DockerRegistryClient.Models;
 
 public class ManifestInfo
 {

--- a/src/Valleysoft.DockerRegistryClient/Models/ManifestList.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/ManifestList.cs
@@ -9,7 +9,7 @@ public class ManifestList : ManifestWithMediaType
 {
     public ManifestList()
     {
-        MediaType = ManifestMediaTypes.ManifestList;
+        MediaType = ManifestMediaTypes.DockerManifestList;
         SchemaVersion = 2;
     }
 

--- a/src/Valleysoft.DockerRegistryClient/Models/OciManifest.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/OciManifest.cs
@@ -1,0 +1,14 @@
+﻿using Newtonsoft.Json;
+
+namespace Valleysoft.DockerRegistryClient.Models;
+
+public class OciManifest : DockerManifestV2
+{
+    public OciManifest()
+    {
+        MediaType = ManifestMediaTypes.OciManifestSchema1;
+    }
+
+    [JsonProperty("annotations")]
+    public IDictionary<string, string> Annotations { get; set; } = new Dictionary<string, string>();
+}

--- a/src/Valleysoft.DockerRegistryClient/Models/OciManifestList.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/OciManifestList.cs
@@ -1,0 +1,14 @@
+﻿using Newtonsoft.Json;
+
+namespace Valleysoft.DockerRegistryClient.Models;
+
+public class OciManifestList : ManifestList
+{
+    public OciManifestList()
+    {
+        MediaType = ManifestMediaTypes.OciManifestList1;
+    }
+
+    [JsonProperty("annotations")]
+    public IDictionary<string, string> Annotations { get; set; } = new Dictionary<string, string>();
+}


### PR DESCRIPTION
The code was not defining the OCI media types as accepted in the request headers so it was not returning back the expected result from registries that supported this. This updates the object model to support the OCI schema as well (specifically, annotations).