### PR TITLE
Support deserialization of image blob

### DIFF
--- a/src/Valleysoft.DockerRegistryClient/Models/Image.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/Image.cs
@@ -1,0 +1,69 @@
+﻿using Newtonsoft.Json;
+
+namespace Valleysoft.DockerRegistryClient.Models;
+
+/// <summary>
+/// An image is an ordered collection of root filesystem changes and the corresponding execution parameters for use within a container runtime.
+/// </summary>
+public class Image
+{
+    /// <summary>
+    /// An combined date and time at which the image was created, formatted as defined by RFC 3339, section 5.6.
+    /// </summary>
+    [JsonProperty("created")]
+    public DateTime? Created { get; set; }
+
+    /// <summary>
+    /// Gives the name and/or email address of the person or entity which created and is responsible for maintaining the image.
+    /// </summary>
+    [JsonProperty("author")]
+    public string? Author { get; set; }
+
+    /// <summary>
+    /// The CPU architecture which the binaries in this image are built to run on.
+    /// </summary>
+    [JsonProperty("architecture")]
+    public string Architecture { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The name of the operating system which the image is built to run on.
+    /// </summary>
+    [JsonProperty("os")]
+    public string Os { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Specifies the version of the operating system targeted by the referenced blob.
+    /// </summary>
+    [JsonProperty("os.version")]
+    public string? OsVersion { get; set; }
+
+    /// <summary>
+    /// This OPTIONAL property specifies an array of strings, each specifying a mandatory OS feature
+    /// </summary>
+    [JsonProperty("os.features")]
+    public string[] OsFeatures { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// The variant of the specified CPU architecture.
+    /// </summary>
+    [JsonProperty("variant")]
+    public string? Variant { get; set; }
+
+    /// <summary>
+    /// The execution parameters which should be used as a base when running a container using the image.
+    /// </summary>
+    [JsonProperty("config")]
+    public ImageConfig? Config { get; set; }
+
+    /// <summary>
+    /// References the layer content addresses used by the image.
+    /// </summary>
+    [JsonProperty("rootfs")]
+    public RootFilesystem RootFilesystem { get; set; } = new RootFilesystem();
+
+    /// <summary>
+    /// Describes the history of each layer. The array is ordered from first to last.
+    /// </summary>
+    [JsonProperty("history")]
+    public LayerHistory[] History { get; set; } = Array.Empty<LayerHistory>();
+}

--- a/src/Valleysoft.DockerRegistryClient/Models/ImageConfig.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/ImageConfig.cs
@@ -1,0 +1,69 @@
+﻿using Newtonsoft.Json;
+
+namespace Valleysoft.DockerRegistryClient.Models;
+
+/// <summary>
+/// The execution parameters which should be used as a base when running a container using the image.
+/// </summary>
+public class ImageConfig
+{
+    /// <summary>
+    /// The username or UID which is a platform-specific structure that allows specific control over which user the process run as.
+    /// </summary>
+    [JsonProperty("User")]
+    public string? User { get; set; }
+
+    /// <summary>
+    /// A set of ports to expose from a container running this image.
+    /// </summary>
+    [JsonProperty("ExposedPorts")]
+    public IDictionary<string, object> ExposedPorts { get; set; } = new Dictionary<string, object>();
+
+    /// <summary>
+    /// Environment variables.
+    /// </summary>
+    [JsonProperty("Env")]
+    public string[] EnvironmentVariables { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// A list of arguments to use as the command to execute when the container starts.
+    /// </summary>
+    [JsonProperty("Entrypoint")]
+    public string[] EntrypointArgs { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Default arguments to the entrypoint of the container.
+    /// </summary>
+    [JsonProperty("Cmd")]
+    public string[] CommandArgs { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// A set of directories describing where the process is likely to write data specific to a container instance.
+    /// </summary>
+    [JsonProperty("Volumes")]
+    public IDictionary<string, object> Volumes { get; set; } = new Dictionary<string, object>();
+
+    /// <summary>
+    /// Sets the current working directory of the entrypoint process in the container.
+    /// </summary>
+    [JsonProperty("WorkingDir")]
+    public string? WorkingDir { get; set; }
+
+    /// <summary>
+    /// List of labels set to the container
+    /// </summary>
+    [JsonProperty("Labels")]
+    public IDictionary<string, string> Labels { get; set; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// Contains the system call signal that will be sent to the container to exit.
+    /// </summary>
+    [JsonProperty("StopSignal")]
+    public string? StopSignal { get; set; }
+
+    /// <summary>
+    /// Indicates that the Entrypoint or Cmd or both, contains only a single element array, that is pre-escaped.
+    /// </summary>
+    [JsonProperty("ArgsEscaped")]
+    public bool ArgsEscaped { get; set; }
+}

--- a/src/Valleysoft.DockerRegistryClient/Models/LayerHistory.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/LayerHistory.cs
@@ -1,0 +1,36 @@
+﻿using Newtonsoft.Json;
+
+namespace Valleysoft.DockerRegistryClient.Models;
+
+public class LayerHistory
+{
+    /// <summary>
+    /// A combined date and time at which the layer was created.
+    /// </summary>
+    [JsonProperty("created")]
+    public DateTime? Created { get; set; }
+
+    /// <summary>
+    /// The command which created the layer.
+    /// </summary>
+    [JsonProperty("created_by")]
+    public string? CreatedBy { get; set; }
+
+    /// <summary>
+    /// The author of the build point.
+    /// </summary>
+    [JsonProperty("author")]
+    public string? Author { get; set; }
+
+    /// <summary>
+    /// A custom message set when creating the layer.
+    /// </summary>
+    [JsonProperty("comment")]
+    public string? Comment { get; set; }
+
+    /// <summary>
+    /// This field is used to mark if the history item created a filesystem diff. It is set to true if this history item doesn't correspond to an actual layer in the rootfs section.
+    /// </summary>
+    [JsonProperty("empty_layer")]
+    public bool IsEmptyLayer { get; set; }
+}

--- a/src/Valleysoft.DockerRegistryClient/Models/ManifestConfig.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/ManifestConfig.cs
@@ -5,7 +5,7 @@ namespace Valleysoft.DockerRegistryClient.Models;
 public class ManifestConfig
 {
     /// <summary>
-    /// The MIME type of the referenced object. This should generally be application/vnd.docker.image.rootfs.diff.tar.gzip. Layers of type application/vnd.docker.image.rootfs.foreign.diff.tar.gzip may be pulled from a remote location but they should never be pushed.
+    /// The MIME type of the referenced object.
     /// </summary>
     [JsonProperty("mediaType")]
     public string? MediaType { get; set; }

--- a/src/Valleysoft.DockerRegistryClient/Models/ManifestPlatform.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/ManifestPlatform.cs
@@ -8,13 +8,13 @@ public class ManifestPlatform
     /// The architecture field specifies the CPU architecture, for example amd64 or ppc64le
     /// </summary>
     [JsonProperty("architecture")]
-    public string? Architecture { get; set; }
+    public string Architecture { get; set; } = string.Empty;
 
     /// <summary>
     /// The os field specifies the operating system, for example linux or windows.
     /// </summary>
     [JsonProperty("os")]
-    public string? Os { get; set; }
+    public string Os { get; set; } = string.Empty;
 
     /// <summary>
     /// The optional os.version field specifies the operating system version, for example 10.0.10586.
@@ -26,7 +26,7 @@ public class ManifestPlatform
     /// The optional os.features field specifies an array of strings, each listing a required OS feature (for example on Windows win32k)
     /// </summary>
     [JsonProperty("os.features")]
-    public string? OsFeatures { get; set; }
+    public string[] OsFeatures { get; set; } = Array.Empty<string>();
 
     /// <summary>
     /// The optional variant field specifies a variant of the CPU, for example armv6l to specify a particular CPU variant of the ARM CPU.

--- a/src/Valleysoft.DockerRegistryClient/Models/RootFilesystem.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/RootFilesystem.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json;
+
+namespace Valleysoft.DockerRegistryClient.Models;
+
+/// <summary>
+/// References the layer content addresses used by the image.
+/// </summary>
+public class RootFilesystem
+{
+    /// <summary>
+    /// Type of the content.
+    /// </summary>
+    [JsonProperty("type")]
+    public string Type { get; set; } = string.Empty;
+
+    // <summary>
+    /// An array of layer content hashes, in order from first to last.
+    /// </summary>
+    [JsonProperty("diff_ids")]
+    public string[] DiffIds { get; set; } = Array.Empty<string>();
+}


### PR DESCRIPTION
This allows blobs with a media type of `application/vnd.docker.container.image.v1+json` or `application/vnd.oci.image.config.v1+json` to be retrieved. It provides an object model for the image schema.