### PR TITLE
Add "ExistsAsync" methods for blobs and manifests

### DIFF
--- a/src/Valleysoft.DockerRegistryClient/BlobOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/BlobOperations.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Rest;
 
 namespace Valleysoft.DockerRegistryClient;
- 
+
 internal class BlobOperations : IServiceOperations<DockerRegistryClient>, IBlobOperations
 {
     public DockerRegistryClient Client { get; }
@@ -15,7 +15,20 @@ internal class BlobOperations : IServiceOperations<DockerRegistryClient>, IBlobO
         string repositoryName, string digest, CancellationToken cancellationToken = default)
     {
         HttpRequestMessage request = new(HttpMethod.Get, $"{this.Client.BaseUri.AbsoluteUri}/v2/{repositoryName}/blobs/{digest}");
-        HttpResponseMessage response = await this.Client.SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
+        HttpResponseMessage response = await this.Client.SendRequestAsync(request, cancellationToken: cancellationToken).ConfigureAwait(false);
         return await DockerRegistryClient.GetStreamContentAsync(request, response).ConfigureAwait(false);
+    }
+
+    public async Task<HttpOperationResponse<bool>> ExistsWithHttpMessagesAsync(
+        string repositoryName, string digest, CancellationToken cancellationToken = default)
+    {
+        HttpRequestMessage request = new(HttpMethod.Head, $"{this.Client.BaseUri.AbsoluteUri}/v2/{repositoryName}/blobs/{digest}");
+        HttpResponseMessage response = await this.Client.SendRequestAsync(request, ignoreUnsuccessfulResponse: true, cancellationToken).ConfigureAwait(false);
+        return new HttpOperationResponse<bool>
+        {
+            Body = response.IsSuccessStatusCode,
+            Request = request,
+            Response = response
+        };
     }
 }

--- a/src/Valleysoft.DockerRegistryClient/BlobOperationsExtensions.cs
+++ b/src/Valleysoft.DockerRegistryClient/BlobOperationsExtensions.cs
@@ -14,6 +14,13 @@ public static class BlobOperationsExtensions
         return new BlobStream(response);
     }
 
+    public static async Task<bool> ExistsAsync(this IBlobOperations operations, string repositoryName, string digest, CancellationToken cancellationToken = default)
+    {
+        HttpOperationResponse<bool> response =
+            await operations.ExistsWithHttpMessagesAsync(repositoryName, digest, cancellationToken).ConfigureAwait(false);
+        return response.Body;
+    }
+
     public static async Task<Image> GetImageAsync(this IBlobOperations operations, string repositoryName, string digest, CancellationToken cancellationToken = default)
     {
         using Stream blob = await operations.GetAsync(repositoryName, digest, cancellationToken);

--- a/src/Valleysoft.DockerRegistryClient/DockerRegistryClient.cs
+++ b/src/Valleysoft.DockerRegistryClient/DockerRegistryClient.cs
@@ -65,11 +65,11 @@ public class DockerRegistryClient : ServiceClient<DockerRegistryClient>
     internal async Task<HttpOperationResponse<T>> SendRequestAsync<T>(HttpRequestMessage request,
         Func<HttpResponseMessage, string, T>? getResult, CancellationToken cancellationToken = default)
     {
-        HttpResponseMessage response = await SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
+        HttpResponseMessage response = await SendRequestAsync(request, cancellationToken: cancellationToken).ConfigureAwait(false);
         return await GetStringContentAsync(request, response, getResult).ConfigureAwait(false);
     }
 
-    internal async Task<HttpResponseMessage> SendRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken = default)
+    internal async Task<HttpResponseMessage> SendRequestAsync(HttpRequestMessage request, bool ignoreUnsuccessfulResponse = false, CancellationToken cancellationToken = default)
     {
         if (this.credentials != null)
         {
@@ -79,6 +79,12 @@ public class DockerRegistryClient : ServiceClient<DockerRegistryClient>
 
         cancellationToken.ThrowIfCancellationRequested();
         HttpResponseMessage response = await this.HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        if (ignoreUnsuccessfulResponse)
+        {
+            return response;
+        }
+
         if (!response.IsSuccessStatusCode)
         {
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/Valleysoft.DockerRegistryClient/IBlobOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/IBlobOperations.cs
@@ -6,4 +6,7 @@ public interface IBlobOperations
 {
     Task<HttpOperationResponse<Stream>> GetWithHttpMessagesAsync(
         string repositoryName, string digest, CancellationToken cancellationToken = default);
+
+    Task<HttpOperationResponse<bool>> ExistsWithHttpMessagesAsync(
+        string repositoryName, string digest, CancellationToken cancellationToken = default);
 }

--- a/src/Valleysoft.DockerRegistryClient/IManifestOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/IManifestOperations.cs
@@ -6,5 +6,6 @@ namespace Valleysoft.DockerRegistryClient;
 public interface IManifestOperations
 {
     Task<HttpOperationResponse<ManifestInfo>> GetWithHttpMessagesAsync(string repositoryName, string tagOrDigest, CancellationToken cancellationToken = default);
+    Task<HttpOperationResponse<bool>> ExistsWithHttpMessagesAsync(string repositoryName, string digest, CancellationToken cancellationToken = default);
     Task<HttpOperationResponse<string>> GetDigestWithHttpMessagesAsync(string repositoryName, string tagOrDigest, CancellationToken cancellationToken = default);
 }

--- a/src/Valleysoft.DockerRegistryClient/ManifestOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/ManifestOperations.cs
@@ -22,6 +22,19 @@ internal class ManifestOperations : IServiceOperations<DockerRegistryClient>, IM
             GetResult,
             cancellationToken);
 
+    public async Task<HttpOperationResponse<bool>> ExistsWithHttpMessagesAsync(
+        string repositoryName, string digest, CancellationToken cancellationToken = default)
+    {
+        HttpRequestMessage request = CreateGetRequestMessage(GetManifestUri(repositoryName, digest), HttpMethod.Head);
+        HttpResponseMessage response = await this.Client.SendRequestAsync(request, ignoreUnsuccessfulResponse: true, cancellationToken).ConfigureAwait(false);
+        return new HttpOperationResponse<bool>
+        {
+            Body = response.IsSuccessStatusCode,
+            Request = request,
+            Response = response
+        };
+    }
+
     public Task<HttpOperationResponse<string>> GetDigestWithHttpMessagesAsync(string repositoryName, string tagOrDigest, CancellationToken cancellationToken = default) =>
         this.Client.SendRequestAsync(
             CreateGetRequestMessage(GetManifestUri(repositoryName, tagOrDigest), HttpMethod.Head),

--- a/src/Valleysoft.DockerRegistryClient/ManifestOperationsExtensions.cs
+++ b/src/Valleysoft.DockerRegistryClient/ManifestOperationsExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Valleysoft.DockerRegistryClient.Models;
+﻿using Microsoft.Rest;
+using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.DockerRegistryClient;
  
@@ -8,6 +9,13 @@ public static class ManifestOperationsExtensions
     {
         var response = await operations.GetWithHttpMessagesAsync(repositoryName, tagOrDigest, cancellationToken).ConfigureAwait(false);
         return response.GetBodyAndDispose();
+    }
+
+    public static async Task<bool> ExistsAsync(this IManifestOperations operations, string repositoryName, string tagOrDigest, CancellationToken cancellationToken = default)
+    {
+        HttpOperationResponse<bool> response =
+            await operations.ExistsWithHttpMessagesAsync(repositoryName, tagOrDigest, cancellationToken).ConfigureAwait(false);
+        return response.Body;
     }
 
     public static async Task<string> GetDigestAsync(this IManifestOperations operations, string repositoryName, string tagOrDigest, CancellationToken cancellationToken = default)


### PR DESCRIPTION
This allows callers to check whether a blob or manifest exists without retrieving its content. This is especially useful for blobs that may be large.