### PR TITLE
Breaking change: Rename DockerRegistryClient and DockerRegistryException

### DIFF
--- a/src/Valleysoft.DockerRegistryClient/BlobOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/BlobOperations.cs
@@ -2,11 +2,11 @@
 
 namespace Valleysoft.DockerRegistryClient;
 
-internal class BlobOperations : IServiceOperations<DockerRegistryClient>, IBlobOperations
+internal class BlobOperations : IServiceOperations<RegistryClient>, IBlobOperations
 {
-    public DockerRegistryClient Client { get; }
+    public RegistryClient Client { get; }
 
-    public BlobOperations(DockerRegistryClient client)
+    public BlobOperations(RegistryClient client)
     {
         this.Client = client;
     }
@@ -16,7 +16,7 @@ internal class BlobOperations : IServiceOperations<DockerRegistryClient>, IBlobO
     {
         HttpRequestMessage request = new(HttpMethod.Get, $"{this.Client.BaseUri.AbsoluteUri}/v2/{repositoryName}/blobs/{digest}");
         HttpResponseMessage response = await this.Client.SendRequestAsync(request, cancellationToken: cancellationToken).ConfigureAwait(false);
-        return await DockerRegistryClient.GetStreamContentAsync(request, response).ConfigureAwait(false);
+        return await RegistryClient.GetStreamContentAsync(request, response).ConfigureAwait(false);
     }
 
     public async Task<HttpOperationResponse<bool>> ExistsWithHttpMessagesAsync(

--- a/src/Valleysoft.DockerRegistryClient/CatalogOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/CatalogOperations.cs
@@ -3,11 +3,11 @@ using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.DockerRegistryClient;
  
-internal class CatalogOperations : IServiceOperations<DockerRegistryClient>, ICatalogOperations
+internal class CatalogOperations : IServiceOperations<RegistryClient>, ICatalogOperations
 {
-    public DockerRegistryClient Client { get; }
+    public RegistryClient Client { get; }
 
-    public CatalogOperations(DockerRegistryClient client)
+    public CatalogOperations(RegistryClient client)
     {
         this.Client = client;
     }
@@ -30,7 +30,7 @@ internal class CatalogOperations : IServiceOperations<DockerRegistryClient>, ICa
 
     private static Page<Catalog> GetResult(HttpResponseMessage response, string content)
     {
-        string? nextLink = DockerRegistryClient.GetNextLinkUrl(response);
-        return new Page<Catalog>(DockerRegistryClient.GetResult<Catalog>(response, content), nextLink);
+        string? nextLink = RegistryClient.GetNextLinkUrl(response);
+        return new Page<Catalog>(RegistryClient.GetResult<Catalog>(response, content), nextLink);
     }
 }

--- a/src/Valleysoft.DockerRegistryClient/ManifestOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/ManifestOperations.cs
@@ -5,13 +5,13 @@ using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.DockerRegistryClient;
  
-internal class ManifestOperations : IServiceOperations<DockerRegistryClient>, IManifestOperations
+internal class ManifestOperations : IServiceOperations<RegistryClient>, IManifestOperations
 {
     private const string DockerContentDigestHeader = "Docker-Content-Digest";
 
-    public DockerRegistryClient Client { get; }
+    public RegistryClient Client { get; }
 
-    public ManifestOperations(DockerRegistryClient client)
+    public ManifestOperations(RegistryClient client)
     {
         this.Client = client;
     }

--- a/src/Valleysoft.DockerRegistryClient/RegistryClient.cs
+++ b/src/Valleysoft.DockerRegistryClient/RegistryClient.cs
@@ -5,7 +5,7 @@ using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.DockerRegistryClient;
  
-public class DockerRegistryClient : ServiceClient<DockerRegistryClient>
+public class RegistryClient : ServiceClient<RegistryClient>
 {
     public string Registry { get; }
     public Uri BaseUri { get; }
@@ -16,33 +16,33 @@ public class DockerRegistryClient : ServiceClient<DockerRegistryClient>
 
     private readonly ServiceClientCredentials? credentials;
 
-    public DockerRegistryClient(string registry)
+    public RegistryClient(string registry)
         : this(registry, null)
     {
     }
 
-    public DockerRegistryClient(string registry, ServiceClientCredentials? serviceClientCredentials)
+    public RegistryClient(string registry, ServiceClientCredentials? serviceClientCredentials)
         : this(registry, serviceClientCredentials, (HttpClientHandler?)null)
     {
             
     }
 
-    public DockerRegistryClient(string registry, ServiceClientCredentials? serviceClientCredentials, HttpClient httpClient, bool disposeHttpClient = true)
+    public RegistryClient(string registry, ServiceClientCredentials? serviceClientCredentials, HttpClient httpClient, bool disposeHttpClient = true)
         : this(registry, serviceClientCredentials, httpClient, disposeHttpClient, null)
     {
     }
 
-    public DockerRegistryClient(string registry, ServiceClientCredentials? serviceClientCredentials, params DelegatingHandler[] handlers)
+    public RegistryClient(string registry, ServiceClientCredentials? serviceClientCredentials, params DelegatingHandler[] handlers)
         : this(registry, serviceClientCredentials, null, handlers)
     {
     }
 
-    public DockerRegistryClient(string registry, ServiceClientCredentials? serviceClientCredentials, HttpClientHandler? rootHandler, params DelegatingHandler[] handlers)
+    public RegistryClient(string registry, ServiceClientCredentials? serviceClientCredentials, HttpClientHandler? rootHandler, params DelegatingHandler[] handlers)
         : this(registry, serviceClientCredentials, null, true, rootHandler, handlers)
     {
     }
 
-    private DockerRegistryClient(string registry, ServiceClientCredentials? serviceClientCredentials, HttpClient? httpClient, bool disposeHttpClient, HttpClientHandler? rootHandler, params DelegatingHandler[] handlers)
+    private RegistryClient(string registry, ServiceClientCredentials? serviceClientCredentials, HttpClient? httpClient, bool disposeHttpClient, HttpClientHandler? rootHandler, params DelegatingHandler[] handlers)
         : base(httpClient, disposeHttpClient)
     {
         this.InitializeHttpClient(httpClient, rootHandler, handlers.Append(new OAuthDelegatingHandler()).ToArray());
@@ -111,8 +111,8 @@ public class DockerRegistryClient : ServiceClient<DockerRegistryClient>
 #endif
             ErrorResult errorResult = SafeJsonConvert.DeserializeObject<ErrorResult>(errorContent);
 
-            throw new DockerRegistryException(
-                $"Response status code does not indicate success: {response.StatusCode}. See {nameof(DockerRegistryException.Errors)} property for more detail. ({response.ReasonPhrase})")
+            throw new RegistryException(
+                $"Response status code does not indicate success: {response.StatusCode}. See {nameof(RegistryException.Errors)} property for more detail. ({response.ReasonPhrase})")
             {
                 Errors = errorResult.Errors,
                 Body = errorContent,

--- a/src/Valleysoft.DockerRegistryClient/RegistryException.cs
+++ b/src/Valleysoft.DockerRegistryClient/RegistryException.cs
@@ -3,18 +3,18 @@ using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.DockerRegistryClient;
 
-public class DockerRegistryException : HttpOperationException
+public class RegistryException : HttpOperationException
 {
-    public DockerRegistryException()
+    public RegistryException()
     {
     }
 
-    public DockerRegistryException(string message)
+    public RegistryException(string message)
         : base(message)
     {
     }
         
-    public DockerRegistryException(string message, Exception innerException)
+    public RegistryException(string message, Exception innerException)
         : base(message, innerException)
     {
     }

--- a/src/Valleysoft.DockerRegistryClient/TagOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/TagOperations.cs
@@ -3,11 +3,11 @@ using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.DockerRegistryClient;
  
-internal class TagOperations : IServiceOperations<DockerRegistryClient>, ITagOperations
+internal class TagOperations : IServiceOperations<RegistryClient>, ITagOperations
 {
-    public DockerRegistryClient Client { get; }
+    public RegistryClient Client { get; }
 
-    public TagOperations(DockerRegistryClient client)
+    public TagOperations(RegistryClient client)
     {
         this.Client = client;
     }
@@ -32,7 +32,7 @@ internal class TagOperations : IServiceOperations<DockerRegistryClient>, ITagOpe
 
     private static Page<RepositoryTags> GetResult(HttpResponseMessage response, string content)
     {
-        string? nextLink = DockerRegistryClient.GetNextLinkUrl(response);
-        return new Page<RepositoryTags>(DockerRegistryClient.GetResult<RepositoryTags>(response, content), nextLink);
+        string? nextLink = RegistryClient.GetNextLinkUrl(response);
+        return new Page<RepositoryTags>(RegistryClient.GetResult<RepositoryTags>(response, content), nextLink);
     }
 }


### PR DESCRIPTION
The name of the `DockerRegistryClient` class conflicted with its containing namespace, causing consuming code to get an error when referencing it with a message like `'DockerRegistryClient' is a namespace but is used like a type`. This forced consuming code to fully-qualify the type name or use namespace tricks to work around this.

To fix this issue, these changes rename `DockerRegistryClient` to `RegistryClient`. A similar change is made for `DockerRegistryException` to `RegistryException` for consistency.