### PR TITLE
Write operations for blobs

### DIFF
--- a/src/Valleysoft.DockerRegistryClient/BlobOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/BlobOperations.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Rest;
+using System.Net.Http.Headers;
 
 namespace Valleysoft.DockerRegistryClient;
 
@@ -11,18 +12,30 @@ internal class BlobOperations : IServiceOperations<RegistryClient>, IBlobOperati
         this.Client = client;
     }
 
+    /// <summary>
+    /// Returns a <see cref="HttpOperationResponse"/> for a data stream of the specified blob.
+    /// </summary>
+    /// <param name="repositoryName">Name of the repository the blob belongs to.</param>
+    /// <param name="digest">Digest of the blob (e.g. "sha256:&lt;value&gt;").</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be canceled.</param>
     public async Task<HttpOperationResponse<Stream>> GetWithHttpMessagesAsync(
         string repositoryName, string digest, CancellationToken cancellationToken = default)
     {
-        HttpRequestMessage request = new(HttpMethod.Get, $"{this.Client.BaseUri.AbsoluteUri}/v2/{repositoryName}/blobs/{digest}");
+        HttpRequestMessage request = new(HttpMethod.Get, $"{this.Client.BaseUri.AbsoluteUri}v2/{repositoryName}/blobs/{digest}");
         HttpResponseMessage response = await this.Client.SendRequestAsync(request, cancellationToken: cancellationToken).ConfigureAwait(false);
         return await RegistryClient.GetStreamContentAsync(request, response).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Returns a <see cref="HttpOperationResponse"/> for the result of whether the specified blob exists.
+    /// </summary>
+    /// <param name="repositoryName">Name of the repository the blob belongs to.</param>
+    /// <param name="digest">Digest of the blob (e.g. "sha256:&lt;value&gt;").</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be canceled.</param>
     public async Task<HttpOperationResponse<bool>> ExistsWithHttpMessagesAsync(
         string repositoryName, string digest, CancellationToken cancellationToken = default)
     {
-        HttpRequestMessage request = new(HttpMethod.Head, $"{this.Client.BaseUri.AbsoluteUri}/v2/{repositoryName}/blobs/{digest}");
+        HttpRequestMessage request = new(HttpMethod.Head, $"{this.Client.BaseUri.AbsoluteUri}v2/{repositoryName}/blobs/{digest}");
         HttpResponseMessage response = await this.Client.SendRequestAsync(request, ignoreUnsuccessfulResponse: true, cancellationToken).ConfigureAwait(false);
         return new HttpOperationResponse<bool>
         {
@@ -30,5 +43,148 @@ internal class BlobOperations : IServiceOperations<RegistryClient>, IBlobOperati
             Request = request,
             Response = response
         };
+    }
+
+    /// <summary>
+    /// Deletes the specified blob.
+    /// </summary>
+    /// <param name="repositoryName">Name of the repository the blob belongs to.</param>
+    /// <param name="digest">Digest of the blob (e.g. "sha256:&lt;value&gt;").</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be canceled.</param>
+    public async Task<HttpOperationResponse> DeleteWithHttpMessagesAsync(
+        string repositoryName, string digest, CancellationToken cancellationToken = default)
+    {
+        HttpRequestMessage request = new(HttpMethod.Delete, $"{this.Client.BaseUri.AbsoluteUri}v2/{repositoryName}/blobs/{digest}");
+        HttpResponseMessage response = await this.Client.SendRequestAsync(request, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return new HttpOperationResponse
+        {
+            Request = request,
+            Response = response
+        };
+    }
+
+    /// <summary>
+    /// Returns a <see cref="HttpOperationResponse"/> for an in-progress blob upload.
+    /// </summary>
+    /// <param name="uploadLocation">The blob location being targeted. This value can be retrieve from the most recently executed result of the <see cref="BeginUploadAsync"/> or <see cref="SendUploadStreamAsync"/> methods.</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be canceled.</param>
+    public async Task<HttpOperationResponse> GetUploadWithHttpMessagesAsync(
+        string uploadLocation, CancellationToken cancellationToken = default)
+    {
+        HttpRequestMessage request = new(HttpMethod.Get, new Uri(Client.BaseUri, uploadLocation));
+        HttpResponseMessage response = await this.Client.SendRequestAsync(request, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return new HttpOperationResponse
+        {
+            Request = request,
+            Response = response
+        };
+    }
+
+    /// <summary>
+    /// Deletes an in-progress blob upload.
+    /// </summary>
+    /// <param name="uploadLocation">The blob location being targeted. This value can be retrieve from the most recently executed result of the <see cref="BeginUploadAsync"/> or <see cref="SendUploadStreamAsync"/> methods.</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be canceled.</param>
+    public async Task<HttpOperationResponse> DeleteUploadWithHttpMessagesAsync(
+        string uploadLocation, CancellationToken cancellationToken = default)
+    {
+        HttpRequestMessage request = new(HttpMethod.Delete, new Uri(Client.BaseUri, uploadLocation));
+        HttpResponseMessage response = await this.Client.SendRequestAsync(request, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return new HttpOperationResponse
+        {
+            Request = request,
+            Response = response
+        };
+    }
+
+    /// <summary>
+    /// Begins a blob upload operation.
+    /// </summary>
+    /// <param name="repositoryName">Name of the repository to upload the blob to.</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be canceled.</param>
+    public async Task<HttpOperationResponse<BlobUploadContext>> BeginUploadWithHttpMessagesAsync(
+        string repositoryName, CancellationToken cancellationToken = default)
+    {
+        HttpRequestMessage request = new(HttpMethod.Post,
+            $"{Client.BaseUri.AbsoluteUri}v2/{repositoryName}/blobs/uploads/");
+
+        HttpResponseMessage response = await this.Client.SendRequestAsync(request, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return new HttpOperationResponse<BlobUploadContext>
+        {
+            // Cache the authorization header for subsequent requests. This avoids re-requesting bearer tokens
+            // for each request within a given client instance. This is particularly important for upload scenarios
+            // where a bunch of data may be sent in the initial request only to be rejected for auth and forced to
+            // upload again.
+            Body = new BlobUploadContext(request.Headers.Authorization),
+            Request = request,
+            Response = response
+        };
+    }
+
+    /// <summary>
+    /// Sends an upload stream as a chunk of the overall data to be uploaded for the blob.
+    /// </summary>
+    /// <param name="uploadLocation">The blob location being targeted. This value can be retrieve from the most recently executed result of the <see cref="BeginUploadAsync"/> or <see cref="SendUploadStreamAsync"/> methods.</param>
+    /// <param name="stream">Data stream to upload as a chunk of the overall blob.</param>
+    /// <param name="uploadContext">The <see cref="BlobUploadContext"/> that was returned in the result of <see cref="BeginUploadAsync"/>.</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be canceled.</param>
+    public async Task<HttpOperationResponse> SendUploadStreamWithHttpMessagesAsync(
+        string uploadLocation, Stream stream, BlobUploadContext uploadContext, CancellationToken cancellationToken = default)
+    {
+#if NETSTANDARD2_0
+        HttpMethod patchMethod = new("PATCH");
+#else
+        HttpMethod patchMethod = HttpMethod.Patch;
+#endif
+        HttpRequestMessage request = new(patchMethod, new Uri(Client.BaseUri, uploadLocation))
+        {
+            Content = CreateStreamContent(stream)
+        };
+        // Reuse the Auth header from the initial upload to avoid re-authenticating and wasting upload time in OAuth flow
+        request.Headers.Authorization = uploadContext.Authorization;
+
+        HttpResponseMessage response = await this.Client.SendRequestAsync(request, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return new HttpOperationResponse
+        {
+            Request = request,
+            Response = response
+        };
+    }
+
+    /// <summary>
+    /// Completes the upload of a blob.
+    /// </summary>
+    /// <param name="uploadLocation">The blob location being targeted. This value can be retrieve from the most recently executed result of the <see cref="BeginUploadAsync"/> or <see cref="SendUploadStreamAsync"/> methods.</param>
+    /// <param name="digest">Digest of the complete data for the blob.</param>
+    /// <param name="uploadContext">The <see cref="BlobUploadContext"/> that was returned in the result of <see cref="BeginUploadAsync"/>.</param>
+    /// <param name="stream">Data stream to upload as a chunk of the overall blob.</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be canceled.</param>
+    public async Task<HttpOperationResponse> EndUploadWithHttpMessagesAsync(
+        string uploadLocation, string digest, BlobUploadContext uploadContext, Stream? stream = null, CancellationToken cancellationToken = default)
+    {
+        Uri uri = new(Client.BaseUri, uploadLocation);
+        char uriAppendChar = string.IsNullOrEmpty(uri.Query) ? '?' : '&';
+        uri = new Uri($"{uri}{uriAppendChar}digest={digest}");
+
+        HttpRequestMessage request = new(HttpMethod.Put, uri)
+        {
+            Content = stream is null ? null : CreateStreamContent(stream)
+        };
+        // Reuse the Auth header from the initial upload to avoid re-authenticating and wasting upload time in OAuth flow
+        request.Headers.Authorization = uploadContext.Authorization;
+
+        HttpResponseMessage response = await this.Client.SendRequestAsync(request, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return new HttpOperationResponse
+        {
+            Request = request,
+            Response = response
+        };
+    }
+
+    private static StreamContent CreateStreamContent(Stream stream)
+    {
+        StreamContent streamContent = new(stream);
+        streamContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        return streamContent;
     }
 }

--- a/src/Valleysoft.DockerRegistryClient/BlobOperationsExtensions.cs
+++ b/src/Valleysoft.DockerRegistryClient/BlobOperationsExtensions.cs
@@ -1,12 +1,26 @@
 ﻿using Microsoft.Rest;
 using Microsoft.Rest.Serialization;
 using Newtonsoft.Json;
+using System.Text.RegularExpressions;
 using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.DockerRegistryClient;
- 
+
+/// <summary>
+/// Extension methods for the <see cref="IBlobOperations"/> interface.
+/// </summary>
 public static class BlobOperationsExtensions
 {
+    private const string RangeHeader = "Range";
+    private const string UuidHeader = "Docker-Upload-UUID";
+
+    /// <summary>
+    /// Returns the data stream of the specified blob.
+    /// </summary>
+    /// <param name="operations">Provider of the blob operations.</param>
+    /// <param name="repositoryName">Name of the repository the blob belongs to.</param>
+    /// <param name="digest">Digest of the blob (e.g. "sha256:&lt;value&gt;").</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be canceled.</param>
     public static async Task<Stream> GetAsync(this IBlobOperations operations, string repositoryName, string digest, CancellationToken cancellationToken = default)
     {
         HttpOperationResponse<Stream> response =
@@ -14,6 +28,14 @@ public static class BlobOperationsExtensions
         return new BlobStream(response);
     }
 
+    /// <summary>
+    /// Checks whether the specified blob exists.
+    /// </summary>
+    /// <param name="operations">Provider of the blob operations.</param>
+    /// <param name="repositoryName">Name of the repository the blob belongs to.</param>
+    /// <param name="digest">Digest of the blob (e.g. "sha256:&lt;value&gt;").</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be canceled.</param>
+    /// <returns>true if the blob exists; otherwise, false.</returns>
     public static async Task<bool> ExistsAsync(this IBlobOperations operations, string repositoryName, string digest, CancellationToken cancellationToken = default)
     {
         HttpOperationResponse<bool> response =
@@ -21,6 +43,24 @@ public static class BlobOperationsExtensions
         return response.Body;
     }
 
+    /// <summary>
+    /// Deletes the specified blob.
+    /// </summary>
+    /// <param name="operations">Provider of the blob operations.</param>
+    /// <param name="repositoryName">Name of the repository the blob belongs to.</param>
+    /// <param name="digest">Digest of the blob (e.g. "sha256:&lt;value&gt;").</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be canceled.</param>
+    public static async Task DeleteAsync(this IBlobOperations operations, string repositoryName, string digest, CancellationToken cancellationToken = default) =>
+        await operations.DeleteWithHttpMessagesAsync(repositoryName, digest, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Returns the object model of a blob that represents an image config (e.g. mediaType of application/vnd.docker.container.image.v1+json or application/vnd.oci.image.config.v1+json).
+    /// </summary>
+    /// <param name="operations">Provider of the blob operations.</param>
+    /// <param name="repositoryName">Name of the repository the blob belongs to.</param>
+    /// <param name="digest">Digest of the blob (e.g. "sha256:&lt;value&gt;").</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be canceled.</param>
+    /// <exception cref="JsonSerializationException">Unable to deserialize the data to the object model.</exception>
     public static async Task<Image> GetImageAsync(this IBlobOperations operations, string repositoryName, string digest, CancellationToken cancellationToken = default)
     {
         using Stream blob = await operations.GetAsync(repositoryName, digest, cancellationToken);
@@ -35,6 +75,154 @@ public static class BlobOperationsExtensions
             throw new JsonSerializationException(
                 "The result could not be deserialized into an image model. Verify the digest represents an image config and not a layer.", e);
         }
+    }
+
+    /// <summary>
+    /// Returns info about an in-progress blob upload.
+    /// </summary>
+    /// <param name="operations">Provider of the blob operations.</param>
+    /// <param name="uploadLocation">The blob location being targeted. This value can be retrieve from the most recently executed result of the <see cref="BeginUploadAsync"/> or <see cref="SendUploadStreamAsync"/> methods.</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be canceled.</param>
+    public static async Task<BlobUpload> GetUploadAsync(this IBlobOperations operations, string uploadLocation, CancellationToken cancellationToken = default)
+    {
+        HttpOperationResponse response =
+            await operations.GetUploadWithHttpMessagesAsync(uploadLocation, cancellationToken).ConfigureAwait(false);
+        HttpResponseMessage responseMsg = response.Response;
+
+        return new BlobUpload(GetUploadId(responseMsg), GetRangeOffset(responseMsg));
+    }
+
+    /// <summary>
+    /// Deletes an in-progress blob upload.
+    /// </summary>
+    /// <param name="operations">Provider of the blob operations.</param>
+    /// <param name="uploadLocation">The blob location being targeted. This value can be retrieve from the most recently executed result of the <see cref="BeginUploadAsync"/> or <see cref="SendUploadStreamAsync"/> methods.</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be canceled.</param>
+    public static async Task DeleteUploadAsync(this IBlobOperations operations, string uploadLocation, CancellationToken cancellationToken = default) =>
+        await operations.DeleteUploadWithHttpMessagesAsync(uploadLocation, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Uploads a blob to the registry.
+    /// </summary>
+    /// <param name="operations">Provider of the blob operations.</param>
+    /// <param name="repositoryName">Name of the repository to upload the blob to.</param>
+    /// <param name="stream">Data stream to upload as the blob.</param>
+    /// <param name="digest">Digest of the data stream (e.g. "sha256:&lt;value&gt;").</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be canceled.</param>
+    /// <remarks>
+    /// This is a convenience method that uses the more primitive <see cref="BeginUploadAsync"/> and <see cref="EndUploadAsync"/> methods.
+    /// </remarks>
+    public static async Task<BlobUploadResult> UploadAsync(this IBlobOperations operations, string repositoryName, Stream stream, string digest, CancellationToken cancellationToken = default)
+    {
+        BlobUploadInitializationResult result = await operations.BeginUploadAsync(repositoryName, cancellationToken).ConfigureAwait(false);
+        return await operations.EndUploadAsync(result.Location, digest, result.UploadContext, stream, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Begins a blob upload operation.
+    /// </summary>
+    /// <param name="operations">Provider of the blob operations.</param>
+    /// <param name="repositoryName">Name of the repository to upload the blob to.</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be canceled.</param>
+    /// <remarks>
+    /// This method estabilishes authentication for the upload process and generates the upload UUID.
+    /// This primitive method can be used over the <see cref="UploadAsync"/> convenience method when you need to have greater control over
+    /// the upload process, such as breaking up the upload into multiple requests to allow for smaller chunks of the data to be retried if the
+    /// upload fails.
+    /// </remarks>
+    public static async Task<BlobUploadInitializationResult> BeginUploadAsync(this IBlobOperations operations, string repositoryName, CancellationToken cancellationToken = default)
+    {
+        HttpOperationResponse<BlobUploadContext> response =
+            await operations.BeginUploadWithHttpMessagesAsync(repositoryName, cancellationToken).ConfigureAwait(false);
+        HttpResponseMessage responseMsg = response.Response;
+
+        return new BlobUploadInitializationResult(GetLocation(responseMsg), GetUploadId(responseMsg), response.Body);
+    }
+
+    /// <summary>
+    /// Sends an upload stream as a chunk of the overall data to be uploaded for the blob.
+    /// </summary>
+    /// <param name="operations">Provider of the blob operations.</param>
+    /// <param name="uploadLocation">The blob location being targeted. This value can be retrieve from the most recently executed result of the <see cref="BeginUploadAsync"/> or <see cref="SendUploadStreamAsync"/> methods.</param>
+    /// <param name="stream">Data stream to upload as a chunk of the overall blob.</param>
+    /// <param name="uploadContext">The <see cref="BlobUploadContext"/> that was returned in the result of <see cref="BeginUploadAsync"/>.</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be canceled.</param>
+    /// <remarks>
+    /// This method is typically used when needing to break up the overall blob data into smaller chunks. It would be called for each
+    /// chunk of the data. The final chunk of the data can be sent via the <see cref="EndUploadAsync"/> method.
+    /// This primitive method can be used over the <see cref="UploadAsync"/> convenience method when you need to have greater control over
+    /// the upload process, such as breaking up the upload into multiple requests to allow for smaller chunks of the data to be retried if the
+    /// upload fails.
+    /// </remarks>
+    public static async Task<BlobUploadStreamResult> SendUploadStreamAsync(this IBlobOperations operations, string uploadLocation, Stream stream, BlobUploadContext uploadContext, CancellationToken cancellationToken = default)
+    {
+        HttpOperationResponse response =
+            await operations.SendUploadStreamWithHttpMessagesAsync(uploadLocation, stream, uploadContext, cancellationToken).ConfigureAwait(false);
+        HttpResponseMessage responseMsg = response.Response;
+
+        return new BlobUploadStreamResult(GetLocation(responseMsg), GetUploadId(responseMsg), GetRangeOffset(responseMsg));
+    }
+
+    /// <summary>
+    /// Completes the upload of a blob.
+    /// </summary>
+    /// <param name="operations">Provider of the blob operations.</param>
+    /// <param name="uploadLocation">The blob location being targeted. This value can be retrieve from the most recently executed result of the <see cref="BeginUploadAsync"/> or <see cref="SendUploadStreamAsync"/> methods.</param>
+    /// <param name="digest">Digest of the complete data for the blob.</param>
+    /// <param name="uploadContext">The <see cref="BlobUploadContext"/> that was returned in the result of <see cref="BeginUploadAsync"/>.</param>
+    /// <param name="stream">Data stream to upload as a chunk of the overall blob.</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be canceled.</param>
+    /// <remarks>
+    /// This method allows you to optionally provide the final (or only) stream of data for the blob. If the stream isn't provided in this method,
+    /// it needs to have been done so via the <see cref="SendUploadStreamAsync"/> method.
+    /// This primitive method can be used over the <see cref="UploadAsync"/> convenience method when you need to have greater control over
+    /// the upload process, such as breaking up the upload into multiple requests to allow for smaller chunks of the data to be retried if the
+    /// upload fails.
+    /// </remarks>
+    public static async Task<BlobUploadResult> EndUploadAsync(this IBlobOperations operations, string uploadLocation, string digest, BlobUploadContext uploadContext, Stream? stream = null, CancellationToken cancellationToken = default)
+    {
+        HttpOperationResponse response =
+            await operations.EndUploadWithHttpMessagesAsync(uploadLocation, digest, uploadContext, stream, cancellationToken).ConfigureAwait(false);
+        HttpResponseMessage responseMsg = response.Response;
+
+        return new BlobUploadResult(GetLocation(responseMsg), GetDigest(responseMsg));
+    }
+
+    private static string GetLocation(HttpResponseMessage responseMsg)
+    {
+        string? location = responseMsg.Headers.Location?.ToString();
+        if (location is null)
+        {
+            throw new Exception("Location header not set.");
+        }
+
+        return location;
+    }
+
+    private static Guid GetUploadId(HttpResponseMessage responseMsg)
+    {
+        string uuid = responseMsg.Headers.GetValues(UuidHeader).First();
+        if (!Guid.TryParse(uuid, out Guid id))
+        {
+            throw new Exception($"Unable to parse {UuidHeader} value '{uuid}'. Expected a valid GUID.");
+        }
+
+        return id;
+    }
+
+    private static string GetDigest(HttpResponseMessage responseMsg) =>
+        responseMsg.Headers.GetValues("Docker-Content-Digest").First();
+
+    private static long GetRangeOffset(HttpResponseMessage responseMsg)
+    {
+        string range = responseMsg.Headers.GetValues(RangeHeader).First();
+        Match match = Regex.Match(range, @"0-(?<offset>\d+)");
+        if (!match.Success)
+        {
+            throw new Exception($"Unable to parse {RangeHeader} value '{range}'. Expected '0-<offset>'");
+        }
+
+        return long.Parse(match.Groups["offset"].Value);
     }
 
     private class BlobStream : Stream

--- a/src/Valleysoft.DockerRegistryClient/BlobUpload.cs
+++ b/src/Valleysoft.DockerRegistryClient/BlobUpload.cs
@@ -1,0 +1,20 @@
+﻿namespace Valleysoft.DockerRegistryClient;
+
+public class BlobUpload
+{
+    public BlobUpload(Guid uploadId, long rangeOffset)
+    {
+        UploadId = uploadId;
+        RangeOffset = rangeOffset;
+    }
+
+    /// <summary>
+    /// Gets the offset from 0 of the inclusive range of bytes that have been uploaded.
+    /// </summary>
+    public long RangeOffset { get; }
+
+    /// <summary>
+    /// Gets the identifier of the blob upload.
+    /// </summary>
+    public Guid UploadId { get; }
+}

--- a/src/Valleysoft.DockerRegistryClient/BlobUploadContext.cs
+++ b/src/Valleysoft.DockerRegistryClient/BlobUploadContext.cs
@@ -1,0 +1,16 @@
+﻿using System.Net.Http.Headers;
+
+namespace Valleysoft.DockerRegistryClient;
+
+/// <summary>
+/// State associated with the initialization of the blob upload.
+/// </summary>
+public class BlobUploadContext
+{
+    internal BlobUploadContext(AuthenticationHeaderValue? authorization)
+    {
+        Authorization = authorization;
+    }
+
+    internal AuthenticationHeaderValue? Authorization { get; }
+}

--- a/src/Valleysoft.DockerRegistryClient/BlobUploadInitializationResult.cs
+++ b/src/Valleysoft.DockerRegistryClient/BlobUploadInitializationResult.cs
@@ -1,0 +1,26 @@
+﻿namespace Valleysoft.DockerRegistryClient;
+
+public class BlobUploadInitializationResult
+{
+    public BlobUploadInitializationResult(string location, Guid uploadId, BlobUploadContext uploadContext)
+    {
+        Location = location;
+        UploadId = uploadId;
+        UploadContext = uploadContext;
+    }
+
+    /// <summary>
+    /// Gets the relative URL of the registry where the blob is located.
+    /// </summary>
+    public string Location { get; }
+
+    /// <summary>
+    /// Gets the identifier of the blob upload.
+    /// </summary>
+    public Guid UploadId { get; }
+
+    /// <summary>
+    /// Gets the state associated with the initialization of the blob upload.
+    /// </summary>
+    public BlobUploadContext UploadContext { get; }
+}

--- a/src/Valleysoft.DockerRegistryClient/BlobUploadResult.cs
+++ b/src/Valleysoft.DockerRegistryClient/BlobUploadResult.cs
@@ -1,0 +1,20 @@
+﻿namespace Valleysoft.DockerRegistryClient;
+
+public class BlobUploadResult
+{
+    public BlobUploadResult(string location, string digest)
+    {
+        Location = location;
+        Digest = digest;
+    }
+
+    /// <summary>
+    /// Gets the relative URL of the registry where the blob is located.
+    /// </summary>
+    public string Location { get; }
+
+    /// <summary>
+    /// Gets the digest of the uploaded blob.
+    /// </summary>
+    public string Digest { get; }
+}

--- a/src/Valleysoft.DockerRegistryClient/BlobUploadStreamResult.cs
+++ b/src/Valleysoft.DockerRegistryClient/BlobUploadStreamResult.cs
@@ -1,0 +1,26 @@
+﻿namespace Valleysoft.DockerRegistryClient;
+
+public class BlobUploadStreamResult
+{
+    public BlobUploadStreamResult(string location, Guid uploadId, long rangeOffset)
+    {
+        Location = location;
+        UploadId = uploadId;
+        RangeOffset = rangeOffset;
+    }
+
+    /// <summary>
+    /// Gets the relative URL of the registry where the blob is located.
+    /// </summary>
+    public string Location { get; }
+
+    /// <summary>
+    /// Gets the identifier of the blob upload.
+    /// </summary>
+    public Guid UploadId { get; }
+
+    /// <summary>
+    /// Gets the offset from 0 of the inclusive range of bytes that have been uploaded.
+    /// </summary>
+    public long RangeOffset { get; }
+}

--- a/src/Valleysoft.DockerRegistryClient/IBlobOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/IBlobOperations.cs
@@ -9,4 +9,22 @@ public interface IBlobOperations
 
     Task<HttpOperationResponse<bool>> ExistsWithHttpMessagesAsync(
         string repositoryName, string digest, CancellationToken cancellationToken = default);
+
+    Task<HttpOperationResponse> DeleteWithHttpMessagesAsync(
+        string repositoryName, string digest, CancellationToken cancellationToken = default);
+
+    Task<HttpOperationResponse> GetUploadWithHttpMessagesAsync(
+        string uploadLocation, CancellationToken cancellationToken = default);
+
+    Task<HttpOperationResponse> DeleteUploadWithHttpMessagesAsync(
+        string uploadLocation, CancellationToken cancellationToken = default);
+
+    Task<HttpOperationResponse<BlobUploadContext>> BeginUploadWithHttpMessagesAsync(
+        string repositoryName, CancellationToken cancellationToken = default);
+
+    Task<HttpOperationResponse> SendUploadStreamWithHttpMessagesAsync(
+        string uploadLocation, Stream stream, BlobUploadContext uploadContext, CancellationToken cancellationToken = default);
+
+    Task<HttpOperationResponse> EndUploadWithHttpMessagesAsync(
+        string uploadLocation, string digest, BlobUploadContext uploadContext, Stream? stream = null, CancellationToken cancellationToken = default);
 }

--- a/src/Valleysoft.DockerRegistryClient/RegistryClient.cs
+++ b/src/Valleysoft.DockerRegistryClient/RegistryClient.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.DockerRegistryClient;
- 
+
 public class RegistryClient : ServiceClient<RegistryClient>
 {
     public string Registry { get; }
@@ -71,7 +71,7 @@ public class RegistryClient : ServiceClient<RegistryClient>
 
     internal async Task<HttpResponseMessage> SendRequestAsync(HttpRequestMessage request, bool ignoreUnsuccessfulResponse = false, CancellationToken cancellationToken = default)
     {
-        if (this.credentials != null)
+        if (this.credentials is not null && request.Headers.Authorization is null)
         {
             cancellationToken.ThrowIfCancellationRequested();
             await this.credentials.ProcessHttpRequestAsync(request, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Adds support for executing write operations for blobs. This provides access to the full set of blob operations. New operations include:

* Delete blob
* Initialize a blob upload (`POST` verb)
* Send stream chunks for a blob upload (`PATCH` verb)
* Complete a blob upload (`PUT` verb)
* Delete an in-progress blob upload
* Get an in-progress blob upload