### PR TITLE
Increase number range for byte size

### DIFF
--- a/src/Valleysoft.DockerRegistryClient/Models/ManifestConfig.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/ManifestConfig.cs
@@ -14,10 +14,10 @@ public class ManifestConfig
     /// The size in bytes of the object. This field exists so that a client will have an expected size for the content before validating. If the length of the retrieved content does not match the specified length, the content should not be trusted.
     /// </summary>
     [JsonProperty("size")]
-    public int? Size { get; set; }
+    public long? Size { get; set; }
 
     /// <summary>
-    /// The digest of the content, as defined by the Registry V2 HTTP API Specificiation. https://docs.docker.com/registry/spec/api/#digest-parameter
+    /// The digest of the content, as defined by the Registry V2 HTTP API Specification. https://docs.docker.com/registry/spec/api/#digest-parameter
     /// </summary>
     [JsonProperty("digest")]
     public string? Digest { get; set; }

--- a/src/Valleysoft.DockerRegistryClient/Models/ManifestLayer.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/ManifestLayer.cs
@@ -14,7 +14,7 @@ public class ManifestLayer
     /// The size in bytes of the object. This field exists so that a client will have an expected size for the content before validating. If the length of the retrieved content does not match the specified length, the content should not be trusted.
     /// </summary>
     [JsonProperty("size")]
-    public int? Size { get; set; }
+    public long? Size { get; set; }
 
     /// <summary>
     /// The digest of the content, as defined by the Registry V2 HTTP API Specification (https://docs.docker.com/registry/spec/api/#digest-parameter).

--- a/src/Valleysoft.DockerRegistryClient/Models/ManifestReference.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/ManifestReference.cs
@@ -14,7 +14,7 @@ public class ManifestReference
     /// The size in bytes of the object. This field exists so that a client will have an expected size for the content before validating. If the length of the retrieved content does not match the specified length, the content should not be trusted.
     /// </summary>
     [JsonProperty("size")]
-    public int? Size { get; set; }
+    public long? Size { get; set; }
 
     /// <summary>
     /// The digest of the content, as defined by the Registry V2 HTTP API Specificiation (https://docs.docker.com/registry/spec/api/#digest-parameter).


### PR DESCRIPTION
The model types for image/manifest schemas do not have a large enough number range for the byte size. Updating the type from `int` to `long`.