### PR TITLE
Provide better error message for not found queries

### DIFF
--- a/src/Valleysoft.DockerRegistryClient/BlobOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/BlobOperations.cs
@@ -23,7 +23,10 @@ internal class BlobOperations : IServiceOperations<RegistryClient>, IBlobOperati
     {
         HttpRequestMessage request = new(HttpMethod.Get, $"{this.Client.BaseUri.AbsoluteUri}v2/{repositoryName}/blobs/{digest}");
         HttpResponseMessage response = await this.Client.SendRequestAsync(request, cancellationToken: cancellationToken).ConfigureAwait(false);
-        return await RegistryClient.GetStreamContentAsync(request, response).ConfigureAwait(false);
+
+        return await OperationsHelper.HandleNotFoundErrorAsync(
+            "Blob not found.",
+            () => RegistryClient.GetStreamContentAsync(request, response)).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Valleysoft.DockerRegistryClient/CatalogOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/CatalogOperations.cs
@@ -18,15 +18,15 @@ internal class CatalogOperations : IServiceOperations<RegistryClient>, ICatalogO
         return GetNextWithHttpMessagesAsync(url, cancellationToken);
     }
 
-    public Task<HttpOperationResponse<Page<Catalog>>> GetNextWithHttpMessagesAsync(string nextPageLink, CancellationToken cancellationToken = default)
-    {
-        return this.Client.SendRequestAsync(
-            new HttpRequestMessage(
-                HttpMethod.Get,
-                new Uri(UrlHelper.Concat(this.Client.BaseUri.AbsoluteUri, nextPageLink))),
-            GetResult,
-            cancellationToken);
-    }
+    public Task<HttpOperationResponse<Page<Catalog>>> GetNextWithHttpMessagesAsync(string nextPageLink, CancellationToken cancellationToken = default) =>
+        OperationsHelper.HandleNotFoundErrorAsync(
+            "Catalog page not found.",
+            () => this.Client.SendRequestAsync(
+                new HttpRequestMessage(
+                    HttpMethod.Get,
+                    new Uri(UrlHelper.Concat(this.Client.BaseUri.AbsoluteUri, nextPageLink))),
+                GetResult,
+                cancellationToken));
 
     private static Page<Catalog> GetResult(HttpResponseMessage response, string content)
     {

--- a/src/Valleysoft.DockerRegistryClient/OperationsHelper.cs
+++ b/src/Valleysoft.DockerRegistryClient/OperationsHelper.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Rest;
+using System.Net;
+
+namespace Valleysoft.DockerRegistryClient;
+
+internal static class OperationsHelper
+{
+    public static async Task<HttpOperationResponse<T>> HandleNotFoundErrorAsync<T>(string errorMessage, Func<Task<HttpOperationResponse<T>>> func)
+    {
+        try
+        {
+            return await func().ConfigureAwait(false);
+        }
+        catch (RegistryException ex) when (ex.Response.StatusCode == HttpStatusCode.NotFound)
+        {
+            throw new RegistryException(errorMessage, ex);
+        }
+    }
+}

--- a/src/Valleysoft.DockerRegistryClient/TagOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/TagOperations.cs
@@ -22,12 +22,14 @@ internal class TagOperations : IServiceOperations<RegistryClient>, ITagOperation
     public Task<HttpOperationResponse<Page<RepositoryTags>>> GetNextWithHttpMessagesAsync(
         string nextPageLink, CancellationToken cancellationToken = default)
     {
-        return this.Client.SendRequestAsync(
-            new HttpRequestMessage(
-                HttpMethod.Get,
-                new Uri(UrlHelper.Concat(this.Client.BaseUri.AbsoluteUri, nextPageLink))),
-            GetResult,
-            cancellationToken);
+        return OperationsHelper.HandleNotFoundErrorAsync(
+            "Repository not found.",
+            () => this.Client.SendRequestAsync(
+                new HttpRequestMessage(
+                    HttpMethod.Get,
+                    new Uri(UrlHelper.Concat(this.Client.BaseUri.AbsoluteUri, nextPageLink))),
+                GetResult,
+                cancellationToken));
     }
 
     private static Page<RepositoryTags> GetResult(HttpResponseMessage response, string content)


### PR DESCRIPTION
When querying for resources that don't exist, the error message that is returned is inconsistent across the different types of resources and generally not a good message.

For example, querying for a manifest that doesn't exist in Docker Hub yields this error message: `manifest unknown`. When querying for a repo that doesn't exist in mcr.microsoft.com, it has this error message:

```
The specified blob does not exist.
RequestId:419fd850-001e-0016-6776-792563000000
Time:2024-03-18T20:51:24.3102332Z
```

These changes provide a common solution for handling NotFound errors for resources.