### PR TITLE
Migrate off of Microsoft.Rest.ClientRuntime

### DIFF
--- a/src/Valleysoft.DockerRegistryClient/BlobOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/BlobOperations.cs
@@ -1,9 +1,8 @@
-﻿using Microsoft.Rest;
-using System.Net.Http.Headers;
+﻿using System.Net.Http.Headers;
 
 namespace Valleysoft.DockerRegistryClient;
 
-internal class BlobOperations : IServiceOperations<RegistryClient>, IBlobOperations
+internal class BlobOperations : IBlobOperations
 {
     public RegistryClient Client { get; }
 
@@ -40,12 +39,7 @@ internal class BlobOperations : IServiceOperations<RegistryClient>, IBlobOperati
     {
         HttpRequestMessage request = new(HttpMethod.Head, $"{this.Client.BaseUri.AbsoluteUri}v2/{repositoryName}/blobs/{digest}");
         HttpResponseMessage response = await this.Client.SendRequestAsync(request, ignoreUnsuccessfulResponse: true, cancellationToken).ConfigureAwait(false);
-        return new HttpOperationResponse<bool>
-        {
-            Body = response.IsSuccessStatusCode,
-            Request = request,
-            Response = response
-        };
+        return new HttpOperationResponse<bool>(request, response, response.IsSuccessStatusCode);
     }
 
     /// <summary>
@@ -59,11 +53,7 @@ internal class BlobOperations : IServiceOperations<RegistryClient>, IBlobOperati
     {
         HttpRequestMessage request = new(HttpMethod.Delete, $"{this.Client.BaseUri.AbsoluteUri}v2/{repositoryName}/blobs/{digest}");
         HttpResponseMessage response = await this.Client.SendRequestAsync(request, cancellationToken: cancellationToken).ConfigureAwait(false);
-        return new HttpOperationResponse
-        {
-            Request = request,
-            Response = response
-        };
+        return new HttpOperationResponse(request, response);
     }
 
     /// <summary>
@@ -76,11 +66,7 @@ internal class BlobOperations : IServiceOperations<RegistryClient>, IBlobOperati
     {
         HttpRequestMessage request = new(HttpMethod.Get, new Uri(Client.BaseUri, uploadLocation));
         HttpResponseMessage response = await this.Client.SendRequestAsync(request, cancellationToken: cancellationToken).ConfigureAwait(false);
-        return new HttpOperationResponse
-        {
-            Request = request,
-            Response = response
-        };
+        return new HttpOperationResponse(request, response);
     }
 
     /// <summary>
@@ -93,11 +79,7 @@ internal class BlobOperations : IServiceOperations<RegistryClient>, IBlobOperati
     {
         HttpRequestMessage request = new(HttpMethod.Delete, new Uri(Client.BaseUri, uploadLocation));
         HttpResponseMessage response = await this.Client.SendRequestAsync(request, cancellationToken: cancellationToken).ConfigureAwait(false);
-        return new HttpOperationResponse
-        {
-            Request = request,
-            Response = response
-        };
+        return new HttpOperationResponse(request, response);
     }
 
     /// <summary>
@@ -112,16 +94,11 @@ internal class BlobOperations : IServiceOperations<RegistryClient>, IBlobOperati
             $"{Client.BaseUri.AbsoluteUri}v2/{repositoryName}/blobs/uploads/");
 
         HttpResponseMessage response = await this.Client.SendRequestAsync(request, cancellationToken: cancellationToken).ConfigureAwait(false);
-        return new HttpOperationResponse<BlobUploadContext>
-        {
-            // Cache the authorization header for subsequent requests. This avoids re-requesting bearer tokens
-            // for each request within a given client instance. This is particularly important for upload scenarios
-            // where a bunch of data may be sent in the initial request only to be rejected for auth and forced to
-            // upload again.
-            Body = new BlobUploadContext(request.Headers.Authorization),
-            Request = request,
-            Response = response
-        };
+        // Cache the authorization header for subsequent requests. This avoids re-requesting bearer tokens
+        // for each request within a given client instance. This is particularly important for upload scenarios
+        // where a bunch of data may be sent in the initial request only to be rejected for auth and forced to
+        // upload again.
+        return new HttpOperationResponse<BlobUploadContext>(request, response, new BlobUploadContext(request.Headers.Authorization));
     }
 
     /// <summary>
@@ -147,11 +124,7 @@ internal class BlobOperations : IServiceOperations<RegistryClient>, IBlobOperati
         request.Headers.Authorization = uploadContext.Authorization;
 
         HttpResponseMessage response = await this.Client.SendRequestAsync(request, cancellationToken: cancellationToken).ConfigureAwait(false);
-        return new HttpOperationResponse
-        {
-            Request = request,
-            Response = response
-        };
+        return new HttpOperationResponse(request, response);
     }
 
     /// <summary>
@@ -177,11 +150,7 @@ internal class BlobOperations : IServiceOperations<RegistryClient>, IBlobOperati
         request.Headers.Authorization = uploadContext.Authorization;
 
         HttpResponseMessage response = await this.Client.SendRequestAsync(request, cancellationToken: cancellationToken).ConfigureAwait(false);
-        return new HttpOperationResponse
-        {
-            Request = request,
-            Response = response
-        };
+        return new HttpOperationResponse(request, response);
     }
 
     private static StreamContent CreateStreamContent(Stream stream)

--- a/src/Valleysoft.DockerRegistryClient/BlobOperationsExtensions.cs
+++ b/src/Valleysoft.DockerRegistryClient/BlobOperationsExtensions.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Rest;
-using Microsoft.Rest.Serialization;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using System.Text.RegularExpressions;
 using Valleysoft.DockerRegistryClient.Models;
 
@@ -66,14 +64,14 @@ public static class BlobOperationsExtensions
         using Stream blob = await operations.GetAsync(repositoryName, digest, cancellationToken);
         using StreamReader reader = new(blob);
         string content = await reader.ReadToEndAsync();
+        const string ErrorMessage = "The result could not be deserialized into an image model. Verify the digest represents an image config and not a layer.";
         try
         {
-            return SafeJsonConvert.DeserializeObject<Image>(content);
+            return JsonConvert.DeserializeObject<Image>(content) ?? throw new JsonSerializationException(ErrorMessage);
         }
         catch (JsonReaderException e)
         {
-            throw new JsonSerializationException(
-                "The result could not be deserialized into an image model. Verify the digest represents an image config and not a layer.", e);
+            throw new JsonSerializationException(ErrorMessage, e);
         }
     }
 

--- a/src/Valleysoft.DockerRegistryClient/CatalogOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/CatalogOperations.cs
@@ -1,9 +1,8 @@
-﻿using Microsoft.Rest;
-using Valleysoft.DockerRegistryClient.Models;
+﻿using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.DockerRegistryClient;
  
-internal class CatalogOperations : IServiceOperations<RegistryClient>, ICatalogOperations
+internal class CatalogOperations : ICatalogOperations
 {
     public RegistryClient Client { get; }
 

--- a/src/Valleysoft.DockerRegistryClient/CatalogOperationsExtensions.cs
+++ b/src/Valleysoft.DockerRegistryClient/CatalogOperationsExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Rest;
-using Valleysoft.DockerRegistryClient.Models;
+﻿using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.DockerRegistryClient;
 

--- a/src/Valleysoft.DockerRegistryClient/CompilerServices.cs
+++ b/src/Valleysoft.DockerRegistryClient/CompilerServices.cs
@@ -1,0 +1,4 @@
+﻿namespace System.Runtime.CompilerServices;
+
+// Needed as workaround: https://stackoverflow.com/a/64749403
+internal static class IsExternalInit { }

--- a/src/Valleysoft.DockerRegistryClient/Credentials/BasicAuthenticationCredentials.cs
+++ b/src/Valleysoft.DockerRegistryClient/Credentials/BasicAuthenticationCredentials.cs
@@ -1,0 +1,22 @@
+﻿using System.Net.Http.Headers;
+using System.Text;
+
+namespace Valleysoft.DockerRegistryClient.Credentials;
+
+public class BasicAuthenticationCredentials : IRegistryClientCredentials
+{
+    public BasicAuthenticationCredentials(string? userName = null, string? password = null)
+    {
+        UserName = userName;
+        Password = password;
+    }
+
+    public string? UserName { get; }
+    public string? Password { get; }
+
+    public Task ProcessHttpRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken = default)
+    {
+        request.Headers.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes($"{UserName}:{Password}")));
+        return Task.CompletedTask;
+    }
+}

--- a/src/Valleysoft.DockerRegistryClient/Credentials/IRegistryClientCredentials.cs
+++ b/src/Valleysoft.DockerRegistryClient/Credentials/IRegistryClientCredentials.cs
@@ -1,0 +1,6 @@
+﻿namespace Valleysoft.DockerRegistryClient.Credentials;
+
+public interface IRegistryClientCredentials
+{
+    Task ProcessHttpRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken = default);
+}

--- a/src/Valleysoft.DockerRegistryClient/Credentials/TokenCredentials.cs
+++ b/src/Valleysoft.DockerRegistryClient/Credentials/TokenCredentials.cs
@@ -1,0 +1,21 @@
+﻿using System.Net.Http.Headers;
+
+namespace Valleysoft.DockerRegistryClient.Credentials;
+
+public class TokenCredentials : IRegistryClientCredentials
+{
+    public TokenCredentials(string token, string tokenType = "Bearer")
+    {
+        Token = token;
+        TokenType = tokenType;
+    }
+
+    public string Token { get; }
+    public string TokenType { get; }
+
+    public Task ProcessHttpRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken = default)
+    {
+        request.Headers.Authorization = new AuthenticationHeaderValue(this.TokenType, this.Token);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Valleysoft.DockerRegistryClient/HttpOperationResponse.cs
+++ b/src/Valleysoft.DockerRegistryClient/HttpOperationResponse.cs
@@ -1,0 +1,23 @@
+﻿namespace Valleysoft.DockerRegistryClient;
+
+
+public record HttpOperationResponse(HttpRequestMessage Request, HttpResponseMessage Response) : IDisposable
+{
+    public void Dispose()
+    {
+        this.Response?.Dispose();
+        this.Request?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}
+
+public record HttpOperationResponse<T> : HttpOperationResponse
+{
+    public HttpOperationResponse(HttpRequestMessage request, HttpResponseMessage response, T body)
+        : base(request, response)
+    {
+        Body = body;
+    }
+
+    public T Body { get; }
+}

--- a/src/Valleysoft.DockerRegistryClient/HttpOperationResponseExtensions.cs
+++ b/src/Valleysoft.DockerRegistryClient/HttpOperationResponseExtensions.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Rest;
-
-namespace Valleysoft.DockerRegistryClient;
+﻿namespace Valleysoft.DockerRegistryClient;
 
 internal static class HttpOperationResponseExtensions
 {

--- a/src/Valleysoft.DockerRegistryClient/IBlobOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/IBlobOperations.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Rest;
-
-namespace Valleysoft.DockerRegistryClient;
+﻿namespace Valleysoft.DockerRegistryClient;
  
 public interface IBlobOperations
 {

--- a/src/Valleysoft.DockerRegistryClient/ICatalogOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/ICatalogOperations.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Rest;
-using Valleysoft.DockerRegistryClient.Models;
+﻿using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.DockerRegistryClient;
  

--- a/src/Valleysoft.DockerRegistryClient/IManifestOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/IManifestOperations.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Rest;
-using Valleysoft.DockerRegistryClient.Models;
+﻿using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.DockerRegistryClient;
  

--- a/src/Valleysoft.DockerRegistryClient/ITagOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/ITagOperations.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Rest;
-using Valleysoft.DockerRegistryClient.Models;
+﻿using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.DockerRegistryClient;
 

--- a/src/Valleysoft.DockerRegistryClient/ManifestOperationsExtensions.cs
+++ b/src/Valleysoft.DockerRegistryClient/ManifestOperationsExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Rest;
-using Valleysoft.DockerRegistryClient.Models;
+﻿using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.DockerRegistryClient;
  

--- a/src/Valleysoft.DockerRegistryClient/OperationsHelper.cs
+++ b/src/Valleysoft.DockerRegistryClient/OperationsHelper.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Rest;
-using System.Net;
+﻿using System.Net;
 
 namespace Valleysoft.DockerRegistryClient;
 
@@ -11,7 +10,7 @@ internal static class OperationsHelper
         {
             return await func().ConfigureAwait(false);
         }
-        catch (RegistryException ex) when (ex.Response.StatusCode == HttpStatusCode.NotFound)
+        catch (RegistryException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
         {
             throw new RegistryException(errorMessage, ex);
         }

--- a/src/Valleysoft.DockerRegistryClient/RegistryException.cs
+++ b/src/Valleysoft.DockerRegistryClient/RegistryException.cs
@@ -1,9 +1,9 @@
-﻿using Microsoft.Rest;
+﻿using System.Net;
 using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.DockerRegistryClient;
 
-public class RegistryException : HttpOperationException
+public class RegistryException : Exception
 {
     public RegistryException()
     {
@@ -20,4 +20,6 @@ public class RegistryException : HttpOperationException
     }
 
     public IEnumerable<Error> Errors { get; set; } = Enumerable.Empty<Error>();
+
+    public HttpStatusCode? StatusCode { get; set; }
 }

--- a/src/Valleysoft.DockerRegistryClient/TagOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/TagOperations.cs
@@ -1,9 +1,8 @@
-﻿using Microsoft.Rest;
-using Valleysoft.DockerRegistryClient.Models;
+﻿using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.DockerRegistryClient;
  
-internal class TagOperations : IServiceOperations<RegistryClient>, ITagOperations
+internal class TagOperations : ITagOperations
 {
     public RegistryClient Client { get; }
 

--- a/src/Valleysoft.DockerRegistryClient/TagOperationsExtensions.cs
+++ b/src/Valleysoft.DockerRegistryClient/TagOperationsExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Rest;
-using Valleysoft.DockerRegistryClient.Models;
+﻿using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.DockerRegistryClient;
  

--- a/src/Valleysoft.DockerRegistryClient/Valleysoft.DockerRegistryClient.csproj
+++ b/src/Valleysoft.DockerRegistryClient/Valleysoft.DockerRegistryClient.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes https://github.com/mthalman/DockerRegistryClient/issues/25

Breaking Changes:

* No longer a dependency on `Microsoft.Rest.ClientRuntime` package
* Types in `Microsoft.Rest.ClientRuntime` that were previously exposed in the DockerRegistryClient API have been replaced with these types:
  * `Microsoft.Rest.ServiceClientCredentials` => `Valleysoft.DockerRegistryClient.Credentials.IRegistryClientCredentials`
  * `Microsoft.Rest.BasicAuthenticationCredentials` => `Valleysoft.DockerRegistryClient.Credentials.BasicAuthenticationCredentials`
  * `Microsoft.Rest.TokenCredentials` => `Valleysoft.DockerRegistryClient.Credentials.TokenCredentials`
* `Valleysoft.DockerRegistryClient.RegistryException` now derives from `Exception` instead of `Microsot.Rest.HttpOperationException`.
* `Valleysoft.DockerRegistryClient.RegistryClient` no longer has constructor overloads for passing handlers. These need to be configured on your own `HttpClient` instance which can be passed to `RegistryClient`.