### PR TITLE
Migrate from Newtonsoft.Json to System.Text.Json

### DIFF
--- a/src/Valleysoft.DockerRegistryClient/BlobOperationsExtensions.cs
+++ b/src/Valleysoft.DockerRegistryClient/BlobOperationsExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json;
 using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.DockerRegistryClient;
@@ -15,7 +15,7 @@ public static class BlobOperationsExtensions
     /// <param name="repositoryName">Name of the repository the blob belongs to.</param>
     /// <param name="digest">Digest of the blob (e.g. "sha256:&lt;value&gt;").</param>
     /// <param name="cancellationToken">Propagates notification that the operation should be canceled.</param>
-    /// <exception cref="JsonSerializationException">Unable to deserialize the data to the object model.</exception>
+    /// <exception cref="JsonException">Unable to deserialize the data to the object model.</exception>
     public static async Task<Image> GetImageAsync(this IBlobOperations operations, string repositoryName, string digest, CancellationToken cancellationToken = default)
     {
         using Stream blob = await operations.GetAsync(repositoryName, digest, cancellationToken);
@@ -24,11 +24,11 @@ public static class BlobOperationsExtensions
         const string ErrorMessage = "The result could not be deserialized into an image model. Verify the digest represents an image config and not a layer.";
         try
         {
-            return JsonConvert.DeserializeObject<Image>(content) ?? throw new JsonSerializationException(ErrorMessage);
+            return JsonSerializer.Deserialize<Image>(content) ?? throw new JsonException(ErrorMessage);
         }
-        catch (JsonReaderException e)
+        catch (JsonException e)
         {
-            throw new JsonSerializationException(ErrorMessage, e);
+            throw new JsonException(ErrorMessage, e);
         }
     }
 

--- a/src/Valleysoft.DockerRegistryClient/ManifestOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/ManifestOperations.cs
@@ -1,5 +1,5 @@
-﻿using Newtonsoft.Json;
-using System.Net.Http.Headers;
+﻿using System.Net.Http.Headers;
+using System.Text.Json;
 using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.DockerRegistryClient;
@@ -88,23 +88,23 @@ internal class ManifestOperations : IManifestOperations
             ManifestMediaTypes.DockerManifestSchema1 or ManifestMediaTypes.DockerManifestSchema1Signed => new ManifestInfo(
                 mediaType,
                 dockerContentDigest,
-                JsonConvert.DeserializeObject<DockerManifestV1>(content) ?? throw new JsonSerializationException($"Unable to deserialize content:{Environment.NewLine}{content}")),
+                JsonSerializer.Deserialize<DockerManifestV1>(content) ?? throw new JsonException($"Unable to deserialize content:{Environment.NewLine}{content}")),
             ManifestMediaTypes.DockerManifestSchema2 => new ManifestInfo(
                 mediaType,
                 dockerContentDigest,
-                JsonConvert.DeserializeObject<DockerManifestV2>(content) ?? throw new JsonSerializationException($"Unable to deserialize content:{Environment.NewLine}{content}")),
+                JsonSerializer.Deserialize<DockerManifestV2>(content) ?? throw new JsonException($"Unable to deserialize content:{Environment.NewLine}{content}")),
             ManifestMediaTypes.DockerManifestList => new ManifestInfo(
                 mediaType,
                 dockerContentDigest,
-                JsonConvert.DeserializeObject<ManifestList>(content) ?? throw new JsonSerializationException($"Unable to deserialize content:{Environment.NewLine}{content}")),
+                JsonSerializer.Deserialize<ManifestList>(content) ?? throw new JsonException($"Unable to deserialize content:{Environment.NewLine}{content}")),
             ManifestMediaTypes.OciManifestSchema1 => new ManifestInfo(
                 mediaType,
                 dockerContentDigest,
-                JsonConvert.DeserializeObject<OciManifest>(content) ?? throw new JsonSerializationException($"Unable to deserialize content:{Environment.NewLine}{content}")),
+                JsonSerializer.Deserialize<OciManifest>(content) ?? throw new JsonException($"Unable to deserialize content:{Environment.NewLine}{content}")),
             ManifestMediaTypes.OciManifestList1 => new ManifestInfo(
                 mediaType,
                 dockerContentDigest,
-                JsonConvert.DeserializeObject<OciManifestList>(content) ?? throw new JsonSerializationException($"Unable to deserialize content:{Environment.NewLine}{content}")),
+                JsonSerializer.Deserialize<OciManifestList>(content) ?? throw new JsonException($"Unable to deserialize content:{Environment.NewLine}{content}")),
             _ => throw new NotSupportedException($"Content type '{mediaType}' not supported."),
         };
     }

--- a/src/Valleysoft.DockerRegistryClient/Models/Catalog.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/Catalog.cs
@@ -1,9 +1,9 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.DockerRegistryClient.Models;
 
 public class Catalog
 {
-    [JsonProperty("repositories")]
+    [JsonPropertyName("repositories")]
     public List<string> RepositoryNames { get; set; } = new List<string>();
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/DockerManifestV1.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/DockerManifestV1.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.DockerRegistryClient.Models;
 
@@ -12,36 +12,36 @@ public class DockerManifestV1 : Manifest
     /// <summary>
     /// Architecture is the host architecture on which this image is intended to run. This is for information purposes and not currently used by the engine.
     /// </summary>
-    [JsonProperty("architecture")]
+    [JsonPropertyName("architecture")]
     public string? Architecture { get; set; }
 
     /// <summary>
     /// Name is the name of the image’s repository.
     /// </summary>
-    [JsonProperty("name")]
+    [JsonPropertyName("name")]
     public string? Name { get; set; }
 
     /// <summary>
     /// History is a list of unstructured historical data for v1 compatibility. It contains ID of the image layer and ID of the layer’s parent layers.
     /// </summary>
-    [JsonProperty("history")]
+    [JsonPropertyName("history")]
     public ManifestHistory[] History { get; set; } = Array.Empty<ManifestHistory>();
 
     /// <summary>
     /// Rag is the tag of the image.
     /// </summary>
-    [JsonProperty("tag")]
+    [JsonPropertyName("tag")]
     public string? Tag { get; set; }
 
     /// <summary>
     /// fsLayers is a list of filesystem layer blob sums contained in this image.
     /// </summary>
-    [JsonProperty("fsLayers")]
+    [JsonPropertyName("fsLayers")]
     public FsLayer[] FsLayers { get; set; } = Array.Empty<FsLayer>();
 
     /// <summary>
     /// Signed manifests provides an envelope for a signed image manifest. A signed manifest consists of an image manifest along with an additional field containing the signature of the manifest.
     /// </summary>
-    [JsonProperty("signatures")]
+    [JsonPropertyName("signatures")]
     public ManifestSignature[] Signatures { get; set; } = Array.Empty<ManifestSignature>();
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/DockerManifestV2.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/DockerManifestV2.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.DockerRegistryClient.Models;
 
@@ -16,12 +16,12 @@ public class DockerManifestV2 : ManifestWithMediaType
     /// <summary>
     /// The config field references a configuration object for a container, by digest. This configuration item is a JSON blob that the runtime uses to set up the container. This new schema uses a tweaked version of this configuration to allow image content-addressability on the daemon side.
     /// </summary>
-    [JsonProperty("config")]
+    [JsonPropertyName("config")]
     public ManifestConfig? Config { get; set; }
 
     /// <summary>
     /// The layer list is ordered starting from the base image (opposite order of schema1).
     /// </summary>
-    [JsonProperty("layers")]
+    [JsonPropertyName("layers")]
     public ManifestLayer[] Layers { get; set; } = Array.Empty<ManifestLayer>();
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/Error.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/Error.cs
@@ -1,16 +1,16 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Valleysoft.DockerRegistryClient.Models;
  
 public class Error
 {
-    [JsonProperty("code")]
+    [JsonPropertyName("code")]
     public string? Code { get; set; }
 
-    [JsonProperty("message")]
+    [JsonPropertyName("message")]
     public string? Message { get; set; }
 
-    [JsonProperty("detail")]
-    public JToken? Detail { get; set; }
+    [JsonPropertyName("detail")]
+    public JsonElement? Detail { get; set; }
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/ErrorResult.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/ErrorResult.cs
@@ -1,9 +1,9 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.DockerRegistryClient.Models;
 
 public class ErrorResult
 {
-    [JsonProperty("errors")]
+    [JsonPropertyName("errors")]
     public Error[] Errors { get; set; } = Array.Empty<Error>();
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/FsLayer.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/FsLayer.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.DockerRegistryClient.Models;
 
@@ -7,6 +7,6 @@ public class FsLayer
     /// <summary>
     /// blobSum is the digest of the referenced filesystem image layer.
     /// </summary>
-    [JsonProperty("blobSum")]
+    [JsonPropertyName("blobSum")]
     public string? BlobSum { get; set; }
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/Image.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/Image.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.DockerRegistryClient.Models;
 
@@ -10,60 +10,60 @@ public class Image
     /// <summary>
     /// An combined date and time at which the image was created, formatted as defined by RFC 3339, section 5.6.
     /// </summary>
-    [JsonProperty("created")]
+    [JsonPropertyName("created")]
     public DateTime? Created { get; set; }
 
     /// <summary>
     /// Gives the name and/or email address of the person or entity which created and is responsible for maintaining the image.
     /// </summary>
-    [JsonProperty("author")]
+    [JsonPropertyName("author")]
     public string? Author { get; set; }
 
     /// <summary>
     /// The CPU architecture which the binaries in this image are built to run on.
     /// </summary>
-    [JsonProperty("architecture")]
+    [JsonPropertyName("architecture")]
     public string Architecture { get; set; } = string.Empty;
 
     /// <summary>
     /// The name of the operating system which the image is built to run on.
     /// </summary>
-    [JsonProperty("os")]
+    [JsonPropertyName("os")]
     public string Os { get; set; } = string.Empty;
 
     /// <summary>
     /// Specifies the version of the operating system targeted by the referenced blob.
     /// </summary>
-    [JsonProperty("os.version")]
+    [JsonPropertyName("os.version")]
     public string? OsVersion { get; set; }
 
     /// <summary>
     /// This OPTIONAL property specifies an array of strings, each specifying a mandatory OS feature
     /// </summary>
-    [JsonProperty("os.features")]
+    [JsonPropertyName("os.features")]
     public string[] OsFeatures { get; set; } = Array.Empty<string>();
 
     /// <summary>
     /// The variant of the specified CPU architecture.
     /// </summary>
-    [JsonProperty("variant")]
+    [JsonPropertyName("variant")]
     public string? Variant { get; set; }
 
     /// <summary>
     /// The execution parameters which should be used as a base when running a container using the image.
     /// </summary>
-    [JsonProperty("config")]
+    [JsonPropertyName("config")]
     public ImageConfig? Config { get; set; }
 
     /// <summary>
     /// References the layer content addresses used by the image.
     /// </summary>
-    [JsonProperty("rootfs")]
+    [JsonPropertyName("rootfs")]
     public RootFilesystem RootFilesystem { get; set; } = new RootFilesystem();
 
     /// <summary>
     /// Describes the history of each layer. The array is ordered from first to last.
     /// </summary>
-    [JsonProperty("history")]
+    [JsonPropertyName("history")]
     public LayerHistory[] History { get; set; } = Array.Empty<LayerHistory>();
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/ImageConfig.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/ImageConfig.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.DockerRegistryClient.Models;
 
@@ -10,60 +10,60 @@ public class ImageConfig
     /// <summary>
     /// The username or UID which is a platform-specific structure that allows specific control over which user the process run as.
     /// </summary>
-    [JsonProperty("User")]
+    [JsonPropertyName("User")]
     public string? User { get; set; }
 
     /// <summary>
     /// A set of ports to expose from a container running this image.
     /// </summary>
-    [JsonProperty("ExposedPorts")]
+    [JsonPropertyName("ExposedPorts")]
     public IDictionary<string, object> ExposedPorts { get; set; } = new Dictionary<string, object>();
 
     /// <summary>
     /// Environment variables.
     /// </summary>
-    [JsonProperty("Env")]
+    [JsonPropertyName("Env")]
     public string[] EnvironmentVariables { get; set; } = Array.Empty<string>();
 
     /// <summary>
     /// A list of arguments to use as the command to execute when the container starts.
     /// </summary>
-    [JsonProperty("Entrypoint")]
+    [JsonPropertyName("Entrypoint")]
     public string[] EntrypointArgs { get; set; } = Array.Empty<string>();
 
     /// <summary>
     /// Default arguments to the entrypoint of the container.
     /// </summary>
-    [JsonProperty("Cmd")]
+    [JsonPropertyName("Cmd")]
     public string[] CommandArgs { get; set; } = Array.Empty<string>();
 
     /// <summary>
     /// A set of directories describing where the process is likely to write data specific to a container instance.
     /// </summary>
-    [JsonProperty("Volumes")]
+    [JsonPropertyName("Volumes")]
     public IDictionary<string, object> Volumes { get; set; } = new Dictionary<string, object>();
 
     /// <summary>
     /// Sets the current working directory of the entrypoint process in the container.
     /// </summary>
-    [JsonProperty("WorkingDir")]
+    [JsonPropertyName("WorkingDir")]
     public string? WorkingDir { get; set; }
 
     /// <summary>
     /// List of labels set to the container
     /// </summary>
-    [JsonProperty("Labels")]
+    [JsonPropertyName("Labels")]
     public IDictionary<string, string> Labels { get; set; } = new Dictionary<string, string>();
 
     /// <summary>
     /// Contains the system call signal that will be sent to the container to exit.
     /// </summary>
-    [JsonProperty("StopSignal")]
+    [JsonPropertyName("StopSignal")]
     public string? StopSignal { get; set; }
 
     /// <summary>
     /// Indicates that the Entrypoint or Cmd or both, contains only a single element array, that is pre-escaped.
     /// </summary>
-    [JsonProperty("ArgsEscaped")]
+    [JsonPropertyName("ArgsEscaped")]
     public bool ArgsEscaped { get; set; }
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/JsonWebKey.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/JsonWebKey.cs
@@ -1,21 +1,21 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.DockerRegistryClient.Models;
 
 public class JsonWebKey
 {
-    [JsonProperty("crv")]
+    [JsonPropertyName("crv")]
     public string? Crv { get; set; }
 
-    [JsonProperty("kid")]
+    [JsonPropertyName("kid")]
     public string? Kid { get; set; }
 
-    [JsonProperty("kty")]
+    [JsonPropertyName("kty")]
     public string? Kty { get; set; }
 
-    [JsonProperty("x")]
+    [JsonPropertyName("x")]
     public string? X { get; set; }
 
-    [JsonProperty("y")]
+    [JsonPropertyName("y")]
     public string? Y { get; set; }
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/LayerHistory.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/LayerHistory.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.DockerRegistryClient.Models;
 
@@ -7,30 +7,30 @@ public class LayerHistory
     /// <summary>
     /// A combined date and time at which the layer was created.
     /// </summary>
-    [JsonProperty("created")]
+    [JsonPropertyName("created")]
     public DateTime? Created { get; set; }
 
     /// <summary>
     /// The command which created the layer.
     /// </summary>
-    [JsonProperty("created_by")]
+    [JsonPropertyName("created_by")]
     public string? CreatedBy { get; set; }
 
     /// <summary>
     /// The author of the build point.
     /// </summary>
-    [JsonProperty("author")]
+    [JsonPropertyName("author")]
     public string? Author { get; set; }
 
     /// <summary>
     /// A custom message set when creating the layer.
     /// </summary>
-    [JsonProperty("comment")]
+    [JsonPropertyName("comment")]
     public string? Comment { get; set; }
 
     /// <summary>
     /// This field is used to mark if the history item created a filesystem diff. It is set to true if this history item doesn't correspond to an actual layer in the rootfs section.
     /// </summary>
-    [JsonProperty("empty_layer")]
+    [JsonPropertyName("empty_layer")]
     public bool IsEmptyLayer { get; set; }
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/Manifest.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/Manifest.cs
@@ -1,9 +1,9 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.DockerRegistryClient.Models;
 
 public abstract class Manifest
 {
-    [JsonProperty("schemaVersion")]
+    [JsonPropertyName("schemaVersion")]
     public int SchemaVersion { get; set; }
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/ManifestConfig.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/ManifestConfig.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.DockerRegistryClient.Models;
  
@@ -7,24 +7,24 @@ public class ManifestConfig
     /// <summary>
     /// The MIME type of the referenced object.
     /// </summary>
-    [JsonProperty("mediaType")]
+    [JsonPropertyName("mediaType")]
     public string? MediaType { get; set; }
 
     /// <summary>
     /// The size in bytes of the object. This field exists so that a client will have an expected size for the content before validating. If the length of the retrieved content does not match the specified length, the content should not be trusted.
     /// </summary>
-    [JsonProperty("size")]
+    [JsonPropertyName("size")]
     public long? Size { get; set; }
 
     /// <summary>
     /// The digest of the content, as defined by the Registry V2 HTTP API Specification. https://docs.docker.com/registry/spec/api/#digest-parameter
     /// </summary>
-    [JsonProperty("digest")]
+    [JsonPropertyName("digest")]
     public string? Digest { get; set; }
 
     /// <summary>
     /// Provides a list of URLs from which the content may be fetched. Content should be verified against the digest and size. This field is optional and uncommon.
     /// </summary>
-    [JsonProperty("urls")]
+    [JsonPropertyName("urls")]
     public string[] Urls { get; set; } = Array.Empty<string>();
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/ManifestHistory.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/ManifestHistory.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.DockerRegistryClient.Models;
 
@@ -7,6 +7,6 @@ public class ManifestHistory
     /// <summary>
     /// V1Compatibility is the raw V1 compatibility information. This will contain the JSON object describing the V1 of this image.
     /// </summary>
-    [JsonProperty("v1Compatibility")]
+    [JsonPropertyName("v1Compatibility")]
     public string? V1Compatibility { get; set; }
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/ManifestLayer.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/ManifestLayer.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.DockerRegistryClient.Models;
 
@@ -7,25 +7,25 @@ public class ManifestLayer
     /// <summary>
     /// The MIME type of the referenced object. This should generally be application/vnd.docker.image.rootfs.diff.tar.gzip. Layers of type application/vnd.docker.image.rootfs.foreign.diff.tar.gzip may be pulled from a remote location but they should never be pushed.
     /// </summary>
-    [JsonProperty("mediaType")]
+    [JsonPropertyName("mediaType")]
     public string? MediaType { get; set; }
 
     /// <summary>
     /// The size in bytes of the object. This field exists so that a client will have an expected size for the content before validating. If the length of the retrieved content does not match the specified length, the content should not be trusted.
     /// </summary>
-    [JsonProperty("size")]
+    [JsonPropertyName("size")]
     public long? Size { get; set; }
 
     /// <summary>
     /// The digest of the content, as defined by the Registry V2 HTTP API Specification (https://docs.docker.com/registry/spec/api/#digest-parameter).
     /// </summary>
-    [JsonProperty("digest")]
+    [JsonPropertyName("digest")]
     public string? Digest { get; set; }
 
     /// <summary>
     /// Provides a list of URLs from which the content may be fetched. Content should be verified against the digest and size. 
     /// This field is optional and uncommon.
     /// </summary>
-    [JsonProperty("urls")]
+    [JsonPropertyName("urls")]
     public string[] Urls { get; set; } = Array.Empty<string>();
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/ManifestList.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/ManifestList.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.DockerRegistryClient.Models;
 
@@ -16,6 +16,6 @@ public class ManifestList : ManifestWithMediaType
     /// <summary>
     /// The manifests field contains a list of manifests for specific platforms.
     /// </summary>
-    [JsonProperty("manifests")]
+    [JsonPropertyName("manifests")]
     public ManifestReference[] Manifests { get; set; } = Array.Empty<ManifestReference>();
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/ManifestPlatform.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/ManifestPlatform.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.DockerRegistryClient.Models;
 
@@ -7,36 +7,36 @@ public class ManifestPlatform
     /// <summary>
     /// The architecture field specifies the CPU architecture, for example amd64 or ppc64le
     /// </summary>
-    [JsonProperty("architecture")]
+    [JsonPropertyName("architecture")]
     public string Architecture { get; set; } = string.Empty;
 
     /// <summary>
     /// The os field specifies the operating system, for example linux or windows.
     /// </summary>
-    [JsonProperty("os")]
+    [JsonPropertyName("os")]
     public string Os { get; set; } = string.Empty;
 
     /// <summary>
     /// The optional os.version field specifies the operating system version, for example 10.0.10586.
     /// </summary>
-    [JsonProperty("os.version")]
+    [JsonPropertyName("os.version")]
     public string? OsVersion { get; set; }
 
     /// <summary>
     /// The optional os.features field specifies an array of strings, each listing a required OS feature (for example on Windows win32k)
     /// </summary>
-    [JsonProperty("os.features")]
+    [JsonPropertyName("os.features")]
     public string[] OsFeatures { get; set; } = Array.Empty<string>();
 
     /// <summary>
     /// The optional variant field specifies a variant of the CPU, for example armv6l to specify a particular CPU variant of the ARM CPU.
     /// </summary>
-    [JsonProperty("variant")]
+    [JsonPropertyName("variant")]
     public string? Variant { get; set; }
 
     /// <summary>
     /// The optional features field specifies an array of strings, each listing a required CPU feature (for example sse4 or aes).
     /// </summary>
-    [JsonProperty("features")]
+    [JsonPropertyName("features")]
     public string[] Features { get; set; } = Array.Empty<string>();
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/ManifestReference.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/ManifestReference.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.DockerRegistryClient.Models;
  
@@ -7,24 +7,24 @@ public class ManifestReference
     /// <summary>
     /// The MIME type of the referenced object. This will generally be application/vnd.docker.image.manifest.v2+json, but it could also be application/vnd.docker.image.manifest.v1+json if the manifest list references a legacy schema-1 manifest.
     /// </summary>
-    [JsonProperty("mediaType")]
+    [JsonPropertyName("mediaType")]
     public string? MediaType { get; set; }
 
     /// <summary>
     /// The size in bytes of the object. This field exists so that a client will have an expected size for the content before validating. If the length of the retrieved content does not match the specified length, the content should not be trusted.
     /// </summary>
-    [JsonProperty("size")]
+    [JsonPropertyName("size")]
     public long? Size { get; set; }
 
     /// <summary>
     /// The digest of the content, as defined by the Registry V2 HTTP API Specificiation (https://docs.docker.com/registry/spec/api/#digest-parameter).
     /// </summary>
-    [JsonProperty("digest")]
+    [JsonPropertyName("digest")]
     public string? Digest { get; set; }
 
     /// <summary>
     /// The platform object describes the platform which the image in the manifest runs on. A full list of valid operating system and architecture values are listed in the Go language documentation for $GOOS and $GOARCH (https://golang.org/doc/install/source#environment).
     /// </summary>
-    [JsonProperty("platform")]
+    [JsonPropertyName("platform")]
     public ManifestPlatform? Platform { get; set; }
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/ManifestSignature.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/ManifestSignature.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.DockerRegistryClient.Models;
 
@@ -7,18 +7,18 @@ public class ManifestSignature
     /// <summary>
     /// A JSON Web Signature (http://self-issued.info/docs/draft-ietf-jose-json-web-signature.html).
     /// </summary>
-    [JsonProperty("header")]
+    [JsonPropertyName("header")]
     public SignatureHeader? Header { get; set; }
 
     /// <summary>
     /// A signature for the image manifest, signed by a libtrust private key.
     /// </summary>
-    [JsonProperty("signature")]
+    [JsonPropertyName("signature")]
     public string? Signature { get; set; }
 
     /// <summary>
     /// The signed protected header.
     /// </summary>
-    [JsonProperty("protected")]
+    [JsonPropertyName("protected")]
     public string? Protected { get; set; }
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/ManifestWithMediaType.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/ManifestWithMediaType.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.DockerRegistryClient.Models;
 
@@ -7,6 +7,6 @@ public abstract class ManifestWithMediaType : Manifest
     /// <summary>
     /// The MIME type of the manifest.
     /// </summary>
-    [JsonProperty("mediaType")]
+    [JsonPropertyName("mediaType")]
     public string? MediaType { get; set; }
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/OAuthToken.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/OAuthToken.cs
@@ -1,18 +1,18 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.DockerRegistryClient.Models;
  
 internal class OAuthToken
 {
-    [JsonProperty("token")]
+    [JsonPropertyName("token")]
     public string? Token { get; set; }
 
-    [JsonProperty("access_token")]
+    [JsonPropertyName("access_token")]
     public string? AccessToken { get; set; }
 
-    [JsonProperty("expires_in")]
+    [JsonPropertyName("expires_in")]
     public int? ExpiresIn { get; set; }
 
-    [JsonProperty("issued_at")]
+    [JsonPropertyName("issued_at")]
     public DateTime? IssuedAt { get; set; }
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/OciManifest.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/OciManifest.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.DockerRegistryClient.Models;
 
@@ -9,6 +9,6 @@ public class OciManifest : DockerManifestV2
         MediaType = ManifestMediaTypes.OciManifestSchema1;
     }
 
-    [JsonProperty("annotations")]
+    [JsonPropertyName("annotations")]
     public IDictionary<string, string> Annotations { get; set; } = new Dictionary<string, string>();
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/OciManifestList.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/OciManifestList.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.DockerRegistryClient.Models;
 
@@ -9,6 +9,6 @@ public class OciManifestList : ManifestList
         MediaType = ManifestMediaTypes.OciManifestList1;
     }
 
-    [JsonProperty("annotations")]
+    [JsonPropertyName("annotations")]
     public IDictionary<string, string> Annotations { get; set; } = new Dictionary<string, string>();
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/RepositoryTags.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/RepositoryTags.cs
@@ -1,12 +1,12 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.DockerRegistryClient.Models;
  
 public class RepositoryTags
 {
-    [JsonProperty("name")]
+    [JsonPropertyName("name")]
     public string? RepositoryName { get; set; }
 
-    [JsonProperty("tags")]
+    [JsonPropertyName("tags")]
     public string[] Tags { get; set; } = Array.Empty<string>();
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/RootFilesystem.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/RootFilesystem.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.DockerRegistryClient.Models;
 
@@ -10,12 +10,12 @@ public class RootFilesystem
     /// <summary>
     /// Type of the content.
     /// </summary>
-    [JsonProperty("type")]
+    [JsonPropertyName("type")]
     public string Type { get; set; } = string.Empty;
 
     // <summary>
     /// An array of layer content hashes, in order from first to last.
     /// </summary>
-    [JsonProperty("diff_ids")]
+    [JsonPropertyName("diff_ids")]
     public string[] DiffIds { get; set; } = Array.Empty<string>();
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/SignatureHeader.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/SignatureHeader.cs
@@ -1,12 +1,12 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.DockerRegistryClient.Models;
 
 public class SignatureHeader
 {
-    [JsonProperty("jwk")]
+    [JsonPropertyName("jwk")]
     public JsonWebKey? Jwk { get; set; }
 
-    [JsonProperty("alg")]
+    [JsonPropertyName("alg")]
     public string? Algorithm { get; set; }
 }

--- a/src/Valleysoft.DockerRegistryClient/OAuthDelegatingHandler.cs
+++ b/src/Valleysoft.DockerRegistryClient/OAuthDelegatingHandler.cs
@@ -1,7 +1,7 @@
-﻿using Newtonsoft.Json;
-using System.Net;
+﻿using System.Net;
 using System.Net.Http.Headers;
 using System.Security.Authentication;
+using System.Text.Json;
 using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.DockerRegistryClient;
@@ -90,11 +90,11 @@ internal class OAuthDelegatingHandler : DelegatingHandler
 
         try
         {
-            return JsonConvert.DeserializeObject<OAuthToken>(tokenContent) ?? throw new JsonSerializationException($"Unable to deserialize response:{Environment.NewLine}{tokenContent}");
+            return JsonSerializer.Deserialize<OAuthToken>(tokenContent) ?? throw new JsonException($"Unable to deserialize response:{Environment.NewLine}{tokenContent}");
         }
         catch (JsonException e)
         {
-            throw new JsonSerializationException($"Unable to deserialize the response:{Environment.NewLine}{tokenContent}", e);
+            throw new JsonException($"Unable to deserialize the response:{Environment.NewLine}{tokenContent}", e);
         }
     }
 }

--- a/src/Valleysoft.DockerRegistryClient/RegistryClient.cs
+++ b/src/Valleysoft.DockerRegistryClient/RegistryClient.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json;
 using System.Xml;
 using System.Xml.Linq;
 using Valleysoft.DockerRegistryClient.Credentials;
@@ -130,7 +130,7 @@ public class RegistryClient : IDisposable
             }
             else
             {
-                errorResult = JsonConvert.DeserializeObject<ErrorResult?>(errorContent);
+                errorResult = JsonSerializer.Deserialize<ErrorResult?>(errorContent);
             }
 
             throw new RegistryException(
@@ -195,7 +195,7 @@ public class RegistryClient : IDisposable
         }
         catch (JsonException e)
         {
-            throw new JsonSerializationException($"Unable to deserialize the response:{Environment.NewLine}{content}", e);
+            throw new JsonException($"Unable to deserialize the response:{Environment.NewLine}{content}", e);
         }
     }
 
@@ -207,7 +207,7 @@ public class RegistryClient : IDisposable
     }
 
     internal static T GetResult<T>(HttpResponseMessage response, string content) =>
-        JsonConvert.DeserializeObject<T>(content) ?? throw new JsonSerializationException($"Unable to deserialize the content:{Environment.NewLine}{content}");
+        JsonSerializer.Deserialize<T>(content) ?? throw new JsonException($"Unable to deserialize the content:{Environment.NewLine}{content}");
 
     internal static string? GetNextLinkUrl(HttpResponseMessage response)
     {

--- a/src/Valleysoft.DockerRegistryClient/Valleysoft.DockerRegistryClient.csproj
+++ b/src/Valleysoft.DockerRegistryClient/Valleysoft.DockerRegistryClient.csproj
@@ -19,7 +19,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Uses System.Text.Json instead of Newtonsoft.Json for JSON deserialization.

Breaking Changes:
* Newtonsoft.Json is no longer included as a dependency of DockerRegistryClient.
* Model classes now use `System.Text.Json.Serialization.JsonPropertyNameAttribute` instead of `Newtonsoft.Json.JsonPropertyAttribute`. If you were using Newtonsoft.Json to serialize any of these model types, the name provided by the attribute would no longer be honored.
* `Valleysoft.DockerRegistryClient.Models.Error.Detail` property changes its type from `Newtonsoft.Json.JToken` to `System.Text.Json.JsonElement`.