### PR TITLE
Change namespace from Image to Images

### DIFF
--- a/src/Valleysoft.DockerRegistryClient/BlobOperationsExtensions.cs
+++ b/src/Valleysoft.DockerRegistryClient/BlobOperationsExtensions.cs
@@ -1,5 +1,5 @@
 ﻿using System.Text.Json;
-using Valleysoft.DockerRegistryClient.Models.Image;
+using Valleysoft.DockerRegistryClient.Models.Images;
 
 namespace Valleysoft.DockerRegistryClient;
 

--- a/src/Valleysoft.DockerRegistryClient/Models/Images/Image.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/Images/Image.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace Valleysoft.DockerRegistryClient.Models.Image;
+namespace Valleysoft.DockerRegistryClient.Models.Images;
 
 // https://github.com/opencontainers/image-spec/blob/v1.0/config.md
 

--- a/src/Valleysoft.DockerRegistryClient/Models/Images/ImageConfig.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/Images/ImageConfig.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace Valleysoft.DockerRegistryClient.Models.Image;
+namespace Valleysoft.DockerRegistryClient.Models.Images;
 
 /// <summary>
 /// The execution parameters which should be used as a base when running a container using the image.

--- a/src/Valleysoft.DockerRegistryClient/Models/Images/LayerHistory.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/Images/LayerHistory.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace Valleysoft.DockerRegistryClient.Models.Image;
+namespace Valleysoft.DockerRegistryClient.Models.Images;
 
 public class LayerHistory
 {

--- a/src/Valleysoft.DockerRegistryClient/Models/Images/RootFilesystem.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/Images/RootFilesystem.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace Valleysoft.DockerRegistryClient.Models.Image;
+namespace Valleysoft.DockerRegistryClient.Models.Images;
 
 /// <summary>
 /// References the layer content addresses used by the image.


### PR DESCRIPTION
Fixing the changes from https://github.com/mthalman/DockerRegistryClient/pull/31 so that that namespace is changed from `Models.Image` to `Models.Images`.