### PR TITLE
Manifest list API updates

### DIFF
--- a/src/Valleysoft.DockerRegistryClient/ManifestOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/ManifestOperations.cs
@@ -1,8 +1,8 @@
 ﻿using System.Net.Http.Headers;
 using System.Text.Json;
-using Valleysoft.DockerRegistryClient.Models.Manifest.Oci;
 using Valleysoft.DockerRegistryClient.Models.Manifests;
 using Valleysoft.DockerRegistryClient.Models.Manifests.Docker;
+using Valleysoft.DockerRegistryClient.Models.Manifests.Oci;
 
 namespace Valleysoft.DockerRegistryClient;
 

--- a/src/Valleysoft.DockerRegistryClient/Models/Manifests/Docker/ManifestConfig.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/Manifests/Docker/ManifestConfig.cs
@@ -21,10 +21,4 @@ public class ManifestConfig : IDescriptor
     /// </summary>
     [JsonPropertyName("digest")]
     public string Digest { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Provides a list of URLs from which the content may be fetched. Content should be verified against the digest and size. This field is optional and uncommon.
-    /// </summary>
-    [JsonPropertyName("urls")]
-    public string[] Urls { get; set; } = Array.Empty<string>();
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/Manifests/Docker/ManifestList.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/Manifests/Docker/ManifestList.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace Valleysoft.DockerRegistryClient.Models.Manifests;
+namespace Valleysoft.DockerRegistryClient.Models.Manifests.Docker;
 
 /// <summary>
 /// The manifest list is the "fat manifest" which points to specific image manifests for one or more platforms. Its use is optional, and relatively few images will use one of these manifests. A client will distinguish a manifest list from an image manifest based on the Content-Type returned in the HTTP response.

--- a/src/Valleysoft.DockerRegistryClient/Models/Manifests/Docker/ManifestReference.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/Manifests/Docker/ManifestReference.cs
@@ -1,26 +1,26 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace Valleysoft.DockerRegistryClient.Models.Manifests;
+namespace Valleysoft.DockerRegistryClient.Models.Manifests.Docker;
 
-public class ManifestReference
+public class ManifestReference : IManifestReference
 {
     /// <summary>
     /// The MIME type of the referenced object. This will generally be application/vnd.docker.image.manifest.v2+json, but it could also be application/vnd.docker.image.manifest.v1+json if the manifest list references a legacy schema-1 manifest.
     /// </summary>
     [JsonPropertyName("mediaType")]
-    public string? MediaType { get; set; }
+    public string MediaType { get; set; } = string.Empty;
 
     /// <summary>
     /// The size in bytes of the object. This field exists so that a client will have an expected size for the content before validating. If the length of the retrieved content does not match the specified length, the content should not be trusted.
     /// </summary>
     [JsonPropertyName("size")]
-    public long? Size { get; set; }
+    public long Size { get; set; }
 
     /// <summary>
     /// The digest of the content, as defined by the Registry V2 HTTP API Specificiation (https://docs.docker.com/registry/spec/api/#digest-parameter).
     /// </summary>
     [JsonPropertyName("digest")]
-    public string? Digest { get; set; }
+    public string Digest { get; set; } = string.Empty;
 
     /// <summary>
     /// The platform object describes the platform which the image in the manifest runs on. A full list of valid operating system and architecture values are listed in the Go language documentation for $GOOS and $GOARCH (https://golang.org/doc/install/source#environment).

--- a/src/Valleysoft.DockerRegistryClient/Models/Manifests/IDescriptor.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/Manifests/IDescriptor.cs
@@ -5,5 +5,4 @@ public interface IDescriptor
     string MediaType { get; }
     long Size { get; }
     string Digest { get; }
-    string[] Urls { get; }
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/Manifests/IManifestList.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/Manifests/IManifestList.cs
@@ -1,0 +1,6 @@
+﻿namespace Valleysoft.DockerRegistryClient.Models.Manifests;
+
+public interface IManifestList : IManifest
+{
+    IManifestReference[] Manifests { get; }
+}

--- a/src/Valleysoft.DockerRegistryClient/Models/Manifests/IManifestReference.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/Manifests/IManifestReference.cs
@@ -1,0 +1,6 @@
+﻿namespace Valleysoft.DockerRegistryClient.Models.Manifests;
+
+public interface IManifestReference : IDescriptor
+{
+    ManifestPlatform? Platform { get; }
+}

--- a/src/Valleysoft.DockerRegistryClient/Models/Manifests/Oci/ManifestReference.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/Manifests/Oci/ManifestReference.cs
@@ -1,0 +1,12 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Valleysoft.DockerRegistryClient.Models.Manifests.Oci;
+
+public class ManifestReference : OciDescriptor, IManifestReference
+{
+    /// <summary>
+    /// The platform object describes the platform which the image in the manifest runs on. A full list of valid operating system and architecture values are listed in the Go language documentation for $GOOS and $GOARCH (https://golang.org/doc/install/source#environment).
+    /// </summary>
+    [JsonPropertyName("platform")]
+    public ManifestPlatform? Platform { get; set; }
+}

--- a/src/Valleysoft.DockerRegistryClient/Models/Manifests/Oci/OciDescriptor.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/Manifests/Oci/OciDescriptor.cs
@@ -1,7 +1,5 @@
 ﻿using System.Text.Json.Serialization;
-using Valleysoft.DockerRegistryClient.Models.Manifests;
-
-namespace Valleysoft.DockerRegistryClient.Models.Manifest.Oci;
+namespace Valleysoft.DockerRegistryClient.Models.Manifests.Oci;
 
 // https://github.com/opencontainers/image-spec/blob/v1.0/descriptor.md
 public class OciDescriptor : IDescriptor
@@ -23,4 +21,7 @@ public class OciDescriptor : IDescriptor
 
     [JsonPropertyName("data")]
     public string? Data { get; set; }
+
+    [JsonPropertyName("artifactType")]
+    public string? ArtifactType { get; set; }
 }

--- a/src/Valleysoft.DockerRegistryClient/Models/Manifests/Oci/OciImageIndex.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/Manifests/Oci/OciImageIndex.cs
@@ -1,14 +1,21 @@
 ﻿using System.Text.Json.Serialization;
-using Valleysoft.DockerRegistryClient.Models.Manifests;
 
-namespace Valleysoft.DockerRegistryClient.Models.Manifest.Oci;
+namespace Valleysoft.DockerRegistryClient.Models.Manifests.Oci;
 
-public class OciImageIndex : ManifestList
+public class OciImageIndex : Manifest, IManifestList
 {
     public OciImageIndex()
     {
         MediaType = ManifestMediaTypes.OciImageIndex1;
     }
+
+    /// <summary>
+    /// The manifests field contains a list of manifests for specific platforms.
+    /// </summary>
+    [JsonPropertyName("manifests")]
+    public ManifestReference[] Manifests { get; set; } = [];
+
+    IManifestReference[] IManifestList.Manifests => Manifests;
 
     [JsonPropertyName("annotations")]
     public IDictionary<string, string> Annotations { get; set; } = new Dictionary<string, string>();

--- a/src/Valleysoft.DockerRegistryClient/Models/Manifests/Oci/OciImageManifest.cs
+++ b/src/Valleysoft.DockerRegistryClient/Models/Manifests/Oci/OciImageManifest.cs
@@ -1,10 +1,9 @@
 ﻿using System.Text.Json.Serialization;
-using Valleysoft.DockerRegistryClient.Models.Manifests;
 
-namespace Valleysoft.DockerRegistryClient.Models.Manifest.Oci;
+namespace Valleysoft.DockerRegistryClient.Models.Manifests.Oci;
 
 // https://github.com/opencontainers/image-spec/blob/v1.0/manifest.md
-public class OciImageManifest : Manifests.Manifest, IImageManifest
+public class OciImageManifest : Manifest, IImageManifest
 {
     public OciImageManifest()
     {


### PR DESCRIPTION
The `OciImageIndex` type graph was missing important parts of the OCI spec. Specifically, it was missing the OCI descriptor fields.

Similar to https://github.com/mthalman/DockerRegistryClient/pull/34, this now defines a common interface for Docker manifest list and OCI image index: `Valleysoft.DockerRegistryClient.Models.Manifests.IManifestList`.

### Breaking Changes

* `ManifestConfig.Urls` property is removed: This should never have existed as it's not defined in the spec for this object.