### PR TITLE
Support for referrers API

### DIFF
--- a/src/Valleysoft.DockerRegistryClient/CatalogOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/CatalogOperations.cs
@@ -27,13 +27,7 @@ internal class CatalogOperations : ICatalogOperations
             "Catalog page not found.",
             () => this.Client.SendRequestAsync(
                 request,
-                GetResult,
+                RegistryClient.GetPageResult<Catalog>,
                 cancellationToken)).ConfigureAwait(false);
-    }
-        
-    private static Page<Catalog> GetResult(HttpResponseMessage response, string content)
-    {
-        string? nextLink = RegistryClient.GetNextLinkUrl(response);
-        return new Page<Catalog>(RegistryClient.GetResult<Catalog>(response, content), nextLink);
     }
 }

--- a/src/Valleysoft.DockerRegistryClient/IReferrerOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/IReferrerOperations.cs
@@ -1,0 +1,22 @@
+﻿using Valleysoft.DockerRegistryClient.Models.Manifests.Oci;
+
+namespace Valleysoft.DockerRegistryClient;
+
+public interface IReferrerOperations
+{
+    /// <summary>
+    /// Gets the list of referrers to the target digest.
+    /// </summary>
+    /// <param name="repositoryName">Name of repository.</param>
+    /// <param name="digest">Digest of the target manifest.</param>
+    /// <param name="artifactType">Artifact media type to filter by.</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be canceled.</param>
+    Task<Page<OciImageIndex>> GetAsync(string repositoryName, string digest, string? artifactType = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the next page of results of the list of referrers.
+    /// </summary>
+    /// <param name="nextPageLink">Link URL contained from the previous <see cref="Page"/> result.</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be canceled.</param>
+    Task<Page<OciImageIndex>> GetNextAsync(string nextPageLink, CancellationToken cancellationToken = default);
+}

--- a/src/Valleysoft.DockerRegistryClient/ReferrerOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/ReferrerOperations.cs
@@ -1,0 +1,38 @@
+﻿using Valleysoft.DockerRegistryClient.Models.Manifests.Oci;
+
+namespace Valleysoft.DockerRegistryClient;
+
+internal class ReferrerOperations : IReferrerOperations
+{
+    public ReferrerOperations(RegistryClient client)
+    {
+        Client = client;
+    }
+
+    public RegistryClient Client { get; }
+
+    public async Task<Page<OciImageIndex>> GetAsync(string repositoryName, string digest, string? artifactType = null, CancellationToken cancellationToken = default)
+    {
+        string url = $"v2/{repositoryName}/referrers/{digest}";
+        if (!string.IsNullOrEmpty(artifactType))
+        {
+            url = $"{url}?artifactType={artifactType}";
+        }
+
+        return await GetNextAsync(url, cancellationToken);
+    }
+
+    public async Task<Page<OciImageIndex>> GetNextAsync(string nextPageLink, CancellationToken cancellationToken = default)
+    {
+        using HttpRequestMessage request = new(
+            HttpMethod.Get,
+            new Uri(UrlHelper.Concat(this.Client.BaseUri.AbsoluteUri, nextPageLink)));
+
+        return await OperationsHelper.HandleNotFoundErrorAsync(
+            $"Manifest not found.",
+            () => this.Client.SendRequestAsync(
+                request,
+                RegistryClient.GetPageResult<OciImageIndex>,
+                cancellationToken)).ConfigureAwait(false);
+    }
+}

--- a/src/Valleysoft.DockerRegistryClient/TagOperations.cs
+++ b/src/Valleysoft.DockerRegistryClient/TagOperations.cs
@@ -27,13 +27,7 @@ internal class TagOperations : ITagOperations
            "Repository not found.",
            () => this.Client.SendRequestAsync(
                request,
-               GetResult,
+               RegistryClient.GetPageResult<RepositoryTags>,
                cancellationToken)).ConfigureAwait(false);
-    }
-
-    private static Page<RepositoryTags> GetResult(HttpResponseMessage response, string content)
-    {
-        string? nextLink = RegistryClient.GetNextLinkUrl(response);
-        return new Page<RepositoryTags>(RegistryClient.GetResult<RepositoryTags>(response, content), nextLink);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/mthalman/DockerRegistryClient/issues/26

Provides an API to query a registry's [referrers API](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers). This returns an `OciImageIndex` containing a list of referrers to the target digest.