### PR TITLE
Target net8.0, net9.0. Drop net6.0

### DIFF
--- a/src/Valleysoft.DockerRegistryClient/Valleysoft.DockerRegistryClient.csproj
+++ b/src/Valleysoft.DockerRegistryClient/Valleysoft.DockerRegistryClient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
Updates the project to target net8.0 and net9.0.
Drops net6.0 since it is EOL.